### PR TITLE
Add CMake presets with strict compiler warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
         description: Artifact name of build dir
         required: false
         type: string
-        default: 'build'
+        default: ''
       cmake-preset:
         description: Specify CMake preset to use
         required: false
@@ -40,8 +40,10 @@ jobs:
       - name: Build
         run: cmake --build build
       - name: Tar artifact (keep permissions)
+        if: ${{ inputs.artifact-name != '' }}
         run: tar -czf build-dir.tar build
       - name: Upload artifact
+        if: ${{ inputs.artifact-name != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.artifact-name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,55 +16,9 @@ on:
         required: false
         type: string
         default: ''
-      is-sanitized:
-        description: Should sanitizers be compiled into the build
-        required: false
-        type: boolean
-        default: false
-      ninja:
-        description: Should Ninja be used as generator
-        required: false
-        type: boolean
-        default: true
-      cmake-args:
-        description: Specify CMake arguments manually
-        required: false
-        type: string
-        default: ''
 jobs:
-  set-cmake-args:
-    name: CMake Args
-    runs-on: ubuntu-latest
-    env:
-      cmake-args: ''
-    outputs:
-      args: ${{ steps.set-output.outputs.result }}
-    steps:
-      - name: Set from manually specified CMake args
-        if: ${{ inputs.cmake-args != '' }}
-        run: echo \"cmake-args=${{ inputs.cmake-args }}\" >> $GITHUB_ENV;
-      - name: Set default CMake args for sanitized build
-        if: ${{ inputs.cmake-args == '' && inputs.is-sanitized }}
-        run: echo "cmake-args=-DECM_ENABLE_SANITIZERS='address;leak;undefined'" >> $GITHUB_ENV"
-      - name: Set default CMake args for coverage build
-        if: ${{ inputs.cmake-args == '' && !inputs.is-sanitized }}
-        run:
-          "echo \"cmake-args=-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_EXE_LINKER_FLAGS=--coverage\" >> $GITHUB_ENV"
-      - name: Set clang as compiler
-        if: ${{ inputs.cmake-args == '' }}
-        run:
-          "echo \"cmake-args=-DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
-            ${{ env.cmake-args }}\" >> $GITHUB_ENV"
-      - name: Set generator
-        if: ${{ inputs.cmake-args == '' && inputs.ninja }}
-        run: echo "cmake-args=-G Ninja ${{ env.cmake-args }}" >> $GITHUB_ENV
-      - id: set-output
-        name: Set resulting variable
-        run: echo "result=${{ env.cmake-args }}" >> "$GITHUB_OUTPUT"
   build:
     name: Build
-    needs: set-cmake-args
     runs-on: ubuntu-latest
     container:
       image: ${{ inputs.image }}
@@ -82,7 +36,7 @@ jobs:
         if: ${{ inputs.cmake-preset != '' }}
         run: echo "cmake-preset=--preset ${{ inputs.cmake-preset }}" >> $GITHUB_ENV
       - name: Configure
-        run: cmake ${{ inputs.cmake-preset }} -S . -B build ${{ needs.set-cmake-args.outputs.args }}
+        run: cmake ${{ env.cmake-preset }} -S . -B build
       - name: Build
         run: cmake --build build
       - name: Tar artifact (keep permissions)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ on:
         required: false
         type: string
         default: 'build'
+      cmake-preset:
+        description: Specify CMake preset to use
+        required: false
+        type: string
+        default: ''
       is-sanitized:
         description: Should sanitizers be compiled into the build
         required: false
@@ -63,6 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ${{ inputs.image }}
+    env:
+      cmake-preset: ''
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -71,8 +78,11 @@ jobs:
         with:
           secret: ${{ secrets.GITHUB_TOKEN }}
       - run: mkdir build
+      - name: Set CMake preset
+        if: ${{ inputs.cmake-preset != '' }}
+        run: echo "cmake-preset=--preset ${{ inputs.cmake-preset }}" >> $GITHUB_ENV
       - name: Configure
-        run: cmake -S . -B build ${{ needs.set-cmake-args.outputs.args }}
+        run: cmake ${{ inputs.cmake-preset }} -S . -B build ${{ needs.set-cmake-args.outputs.args }}
       - name: Build
         run: cmake --build build
       - name: Tar artifact (keep permissions)

--- a/.github/workflows/change.yml
+++ b/.github/workflows/change.yml
@@ -15,6 +15,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
+      cmake-preset: coverage
 
   install:
     uses: ./.github/workflows/install.yml

--- a/.github/workflows/change.yml
+++ b/.github/workflows/change.yml
@@ -11,23 +11,32 @@ jobs:
   clang-format:
     uses: ./.github/workflows/clang-format.yml
 
-  build:
+  clang-build:
     uses: ./.github/workflows/build.yml
     with:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
+      artifact-name: clang-build
       cmake-preset: coverage
+
+  gcc-build:
+    uses: ./.github/workflows/build.yml
+    with:
+      image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
+      cmake-preset: gcc
 
   install:
     uses: ./.github/workflows/install.yml
-    needs: build
+    needs: clang-build
     with:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
+      artifact-name: clang-build
 
   test:
     uses: ./.github/workflows/test.yml
-    needs: build
+    needs: clang-build
     with:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
+      artifact-name: clang-build
       ctest-args:
         "-E 'lockscreen|modifier only shortcut|no crash empty deco|no crash no border\
           |scene opengl|opengl shadow|no crash reinit compositor|buffer size change\
@@ -36,7 +45,8 @@ jobs:
 
   package:
     uses: ./.github/workflows/package.yml
-    needs: build
+    needs: clang-build
     with:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
+      artifact-name: clang-build
       package-name: como

--- a/.github/workflows/change.yml
+++ b/.github/workflows/change.yml
@@ -18,11 +18,14 @@ jobs:
       artifact-name: clang-build
       cmake-preset: coverage
 
-  gcc-build:
+  secondary-builds:
+    strategy:
+      matrix:
+        preset: [gcc, release]
     uses: ./.github/workflows/build.yml
     with:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
-      cmake-preset: gcc
+      cmake-preset: ${{ matrix.preset }}
 
   install:
     uses: ./.github/workflows/install.yml

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -9,7 +9,7 @@ jobs:
     with:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
       artifact-name: build
-      cmake-preset: clang
+      cmake-preset: release
 
   package:
     uses: ./.github/workflows/package.yml

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -8,6 +8,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
+      cmake-preset: clang
 
   package:
     uses: ./.github/workflows/package.yml

--- a/.github/workflows/rebuild.yml
+++ b/.github/workflows/rebuild.yml
@@ -8,6 +8,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
+      artifact-name: build
       cmake-preset: clang
 
   package:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,8 @@ on:
         type: string
       artifact-name:
         description: Artifact name of build dir
-        required: false
+        required: true
         type: string
-        default: 'build'
       ctest-args:
         description: Specify additional CTest arguments
         required: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,12 +54,10 @@ set_package_properties(Qt6Test PROPERTIES
     TYPE OPTIONAL
 )
 add_feature_info("Qt6Test" Qt6Test_FOUND "Required for building tests")
-if (NOT Qt6Test_FOUND)
-    set(BUILD_TESTING OFF CACHE BOOL "Build the testing tree.")
-endif()
 
 include(KDEInstallDirs)
-include(KDECMakeSettings)
+include(CMakeSettings)
+include(CTest)
 
 include(ECMInstallIcons)
 include(ECMOptionalAddSubdirectory)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,17 +8,19 @@ project("The Compositor Modules" VERSION 0.1.0)
 
 set(QT_MIN_VERSION "6.4.0")
 set(KF6_MIN_VERSION "5.240.0")
-set(KDE_COMPILERSETTINGS_LEVEL "5.84")
 set(KDE_PLASMA_VERSION "5.27")
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-add_definitions(-DQT_DISABLE_DEPRECATED_BEFORE=0
-  -DQT_NO_KEYWORDS
-  -DQT_USE_QSTRINGBUILDER
+add_definitions(
   -DQT_NO_URL_CAST_FROM_STRING
+  -DQT_USE_QSTRINGBUILDER
+  -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT
+  -DQT_NO_KEYWORDS
+  -DQT_NO_FOREACH
+  -DQT_STRICT_ITERATORS
   -DQT_NO_CAST_TO_ASCII
 )
 
@@ -58,15 +60,6 @@ endif()
 
 include(KDEInstallDirs)
 include(KDECMakeSettings)
-include(KDECompilerSettings NO_POLICY_SCOPE)
-
-# TODO(romangg): The KDECompilerSettings include adds cast-align warnings. But with wlroots and
-#     libwayland we have too many C casts like this. For now disable the cast-align warning again.
-#     Should we instead wrap the calls and disable the warnings with pragma more targeted?
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-cast-align")
-
-# Produces a lot of warnings with gcc on structs where we default-initialize some fields.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-field-initializers")
 
 include(ECMInstallIcons)
 include(ECMOptionalAddSubdirectory)
@@ -309,11 +302,15 @@ ecm_find_qmlmodule(org.kde.kquickcontrolsaddons 2.0)
 ecm_find_qmlmodule(org.kde.plasma.core 2.0)
 ecm_find_qmlmodule(org.kde.plasma.components 2.0)
 
-########### configure tests ###############
 option(COMO_BUILD_DECORATIONS "Enable building of decorations." ON)
 option(COMO_BUILD_KCMS "Enable building of configuration modules." ON)
 option(COMO_BUILD_TABBOX "Enable building of Tabbox functionality" ON)
 option(COMO_BUILD_PERF "Build internal tools for performance analysis at runtime." ON)
+
+# Default to hidden visibility for symbols
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
 set(COMO_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(HAVE_PERF ${COMO_BUILD_PERF})

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,89 @@
+{
+  "version": 4,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 23,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "debug-base",
+      "hidden": true,
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      },
+      "environment": {
+        "DEBUG_COMMON_FLAGS": "-Wall -Wextra -Wchar-subscripts -Wformat-security -Wno-long-long -Wpointer-arith -Wundef",
+        "DEBUG_C_FLAGS": "$env{DEBUG_COMMON_FLAGS} -Wmissing-format-attribute -Wwrite-strings -Werror=implicit-function-declaration",
+        "DEBUG_CXX_FLAGS": "$env{DEBUG_COMMON_FLAGS} -fno-operator-names -Wnon-virtual-dtor -Woverloaded-virtual -Wvla -Wdate-time -pedantic -Wzero-as-null-pointer-constant -Werror=return-type -Werror=init-self -Werror=undef -fdiagnostics-color=always",
+        "DEBUG_SHARED_LINKER_FLAGS": "-Wl,--fatal-warnings",
+        "DEBUG_MODULE_LINKER_FLAGS": "-Wl,--fatal-warnings",
+        "NOUNDEF_LINKER_FLAGS": "-Wl,--no-undefined",
+        "DEBUG_CXX_FLAGS_CLANG": "$env{DEBUG_CXX_FLAGS} -fno-operator-names -Wno-gnu-zero-variadic-macro-arguments"
+      }
+    },
+    {
+      "name": "clang",
+      "inherits": "debug-base",
+      "displayName": "Clang Config",
+      "description": "Default build using Ninja and Clang",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_C_FLAGS": "$env{DEBUG_C_FLAGS}",
+        "CMAKE_CXX_FLAGS": "$env{DEBUG_CXX_FLAGS_CLANG}",
+        "CMAKE_SHARED_LINKER_FLAGS": "$env{DEBUG_SHARED_LINKER_FLAGS} $env{NOUNDEF_LINKER_FLAGS}",
+        "CMAKE_MODULE_LINKER_FLAGS": "$env{DEBUG_MODULE_LINKER_FLAGS} $env{NOUNDEF_LINKER_FLAGS}"
+      }
+    },
+    {
+      "name": "gcc",
+      "inherits": "debug-base",
+      "displayName": "GCC Config",
+      "description": "Build using Ninja and GCC",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
+        "CMAKE_C_FLAGS": "$env{DEBUG_C_FLAGS}",
+        "CMAKE_CXX_FLAGS": "$env{DEBUG_CXX_FLAGS} -Wsuggest-override -Wlogical-op -Wmissing-include-dirs",
+        "CMAKE_SHARED_LINKER_FLAGS": "$env{DEBUG_SHARED_LINKER_FLAGS} $env{NOUNDEF_LINKER_FLAGS}",
+        "CMAKE_MODULE_LINKER_FLAGS": "$env{DEBUG_MODULE_LINKER_FLAGS} $env{NOUNDEF_LINKER_FLAGS}"
+      }
+    },
+    {
+      "name": "sanitizers",
+      "inherits": "debug-base",
+      "displayName": "Sanitizers Build",
+      "description": "Build with common sanitizers",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_C_FLAGS": "$env{DEBUG_C_FLAGS}",
+        "CMAKE_CXX_FLAGS": "$env{DEBUG_CXX_FLAGS_CLANG}",
+        "ECM_ENABLE_SANITIZERS": "address;leak;undefined",
+        "CMAKE_SHARED_LINKER_FLAGS": "$env{DEBUG_SHARED_LINKER_FLAGS}",
+        "CMAKE_MODULE_LINKER_FLAGS": "$env{DEBUG_MODULE_LINKER_FLAGS}"
+      }
+    },
+    {
+      "name": "coverage",
+      "inherits": "debug-base",
+      "displayName": "Tests with Coverage",
+      "description": "Build with tests and coverage reporting enabled",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_C_FLAGS": "$env{DEBUG_C_FLAGS}",
+        "CMAKE_CXX_FLAGS": "$env{DEBUG_CXX_FLAGS_CLANG} --coverage",
+        "CMAKE_SHARED_LINKER_FLAGS": "$env{DEBUG_SHARED_LINKER_FLAGS} $env{NOUNDEF_LINKER_FLAGS}",
+        "CMAKE_MODULE_LINKER_FLAGS": "$env{DEBUG_MODULE_LINKER_FLAGS} $env{NOUNDEF_LINKER_FLAGS}",
+        "CMAKE_EXE_LINKER_FLAGS": "--coverage",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": {
+          "type": "BOOL",
+          "value": "ON"
+        }
+      }
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -84,6 +84,21 @@
           "value": "ON"
         }
       }
+    },
+    {
+      "name": "release",
+      "displayName": "Release build",
+      "description": "Build without any checks as release with debug symbols",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "BUILD_TESTING": {
+          "type": "BOOL",
+          "value": "OFF"
+        }
+      }
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -46,7 +46,7 @@
         "CMAKE_C_COMPILER": "gcc",
         "CMAKE_CXX_COMPILER": "g++",
         "CMAKE_C_FLAGS": "$env{DEBUG_C_FLAGS}",
-        "CMAKE_CXX_FLAGS": "$env{DEBUG_CXX_FLAGS} -Wsuggest-override -Wlogical-op -Wmissing-include-dirs",
+        "CMAKE_CXX_FLAGS": "$env{DEBUG_CXX_FLAGS} -Wsuggest-override -Wlogical-op -Wmissing-include-dirs -Wno-missing-field-initializers -Werror -Wno-error=unknown-pragmas -Wno-error=deprecated-declarations -Wno-error=missing-include-dirs",
         "CMAKE_SHARED_LINKER_FLAGS": "$env{DEBUG_SHARED_LINKER_FLAGS} $env{NOUNDEF_LINKER_FLAGS}",
         "CMAKE_MODULE_LINKER_FLAGS": "$env{DEBUG_MODULE_LINKER_FLAGS} $env{NOUNDEF_LINKER_FLAGS}"
       }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -20,7 +20,7 @@
         "DEBUG_SHARED_LINKER_FLAGS": "-Wl,--fatal-warnings",
         "DEBUG_MODULE_LINKER_FLAGS": "-Wl,--fatal-warnings",
         "NOUNDEF_LINKER_FLAGS": "-Wl,--no-undefined",
-        "DEBUG_CXX_FLAGS_CLANG": "$env{DEBUG_CXX_FLAGS} -fno-operator-names -Wno-gnu-zero-variadic-macro-arguments -Wno-cast-align"
+        "DEBUG_CXX_FLAGS_CLANG": "$env{DEBUG_CXX_FLAGS} -fno-operator-names -Wno-gnu-zero-variadic-macro-arguments -Wno-cast-align -Werror -Wno-error=deprecated-declarations -Wno-error=unused-lambda-capture"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -20,7 +20,7 @@
         "DEBUG_SHARED_LINKER_FLAGS": "-Wl,--fatal-warnings",
         "DEBUG_MODULE_LINKER_FLAGS": "-Wl,--fatal-warnings",
         "NOUNDEF_LINKER_FLAGS": "-Wl,--no-undefined",
-        "DEBUG_CXX_FLAGS_CLANG": "$env{DEBUG_CXX_FLAGS} -fno-operator-names -Wno-gnu-zero-variadic-macro-arguments"
+        "DEBUG_CXX_FLAGS_CLANG": "$env{DEBUG_CXX_FLAGS} -fno-operator-names -Wno-gnu-zero-variadic-macro-arguments -Wno-cast-align"
       }
     },
     {

--- a/README.md
+++ b/README.md
@@ -108,11 +108,19 @@ Well defined and transparent decision processes enable expert knowledge to proli
 and new contributors to easily find help on their first steps.
 
 # Installation
-The Compositor Modules can be compiled from source.
-If you do that manually you have to check for your specific distribution
-how to best get the required dependencies.
+The Compositor Modules can be compiled from source easily through CMake presets.
+To use the preset for a release configuration building into a subdirectory `build`,
+issue from the source directory:
 
-You can also make use of the FDBuild tool to automate that process as described
+```
+cmake --preset release -B build
+cmake --build build
+```
+
+Since The Compositor Module's master branch regularly only builds
+against the development versions of KDE Plasma libraries,
+you might want to build these dependencies from source too.
+You can make use of the FDBuild tool to automate this process as described
 [here](CONTRIBUTING.md#compiling).
 
 # Usage
@@ -121,13 +129,6 @@ and then create their central platform types from your main function to launch t
 
 [Minico](tests/minico) as a minimal example and the [Plasma test binaries](tests/plasma)
 as a more complex one demonstrate this in a straightforward way.
-
-# Development
-The [CONTRIBUTING.md](CONTRIBUTING.md) document contains all information
-on how to get started with:
-* providing useful debug information,
-* building The Compositor Modules
-* and doing your first code submission to the project.
 
 # Contact
 Issue tickets can be created for feature requests, bug reports or general discussions.

--- a/autotests/integration/global_shortcuts.cpp
+++ b/autotests/integration/global_shortcuts.cpp
@@ -54,19 +54,24 @@ TEST_CASE("global shortcuts", "[input]")
                                       mod_data{KEY_LEFTSHIFT, Qt::SHIFT},
                                       mod_data{KEY_LEFTMETA, Qt::META});
 
+        // TODO(romangg): grave key is still not working with Qt6.
+        // More common case with any Latin1 symbol keys, including punctuation,
+        // should work also. "`" key has a "ё" letter on Russian layout.
+        // FIXME: QTBUG-90611
+#if 1
         auto key_test_data = GENERATE(
             // Tab is example of a key usually the same on different layouts, check it first.
             key_data{KEY_TAB, Qt::Key_Tab},
-#if 1
             // Then check a key with a Latin letter. The symbol will probably be differ on non-Latin
             // layout. On Russian layout, "w" key has a cyrillic letter "ц".
             key_data{KEY_W, Qt::Key_W});
 #else
+        auto key_test_data = GENERATE(
+            // Tab is example of a key usually the same on different layouts, check it first.
+            key_data{KEY_TAB, Qt::Key_Tab},
+            // Then check a key with a Latin letter. The symbol will probably be differ on non-Latin
+            // layout. On Russian layout, "w" key has a cyrillic letter "ц".
             key_data{KEY_W, Qt::Key_W},
-            // TODO(romangg): grave key is still not working with Qt6.
-            // More common case with any Latin1 symbol keys, including punctuation,
-            // should work also. "`" key has a "ё" letter on Russian layout.
-            // FIXME: QTBUG-90611
             key_data{KEY_GRAVE, Qt::Key_QuoteLeft});
 #endif
 

--- a/autotests/integration/internal_window.cpp
+++ b/autotests/integration/internal_window.cpp
@@ -90,20 +90,20 @@ bool HelperWindow::event(QEvent* event)
 
 void HelperWindow::mouseMoveEvent(QMouseEvent* event)
 {
-    m_latestGlobalMousePos = event->globalPos();
-    Q_EMIT mouseMoved(event->globalPos());
+    m_latestGlobalMousePos = event->globalPosition().toPoint();
+    Q_EMIT mouseMoved(event->globalPosition().toPoint());
 }
 
 void HelperWindow::mousePressEvent(QMouseEvent* event)
 {
-    m_latestGlobalMousePos = event->globalPos();
+    m_latestGlobalMousePos = event->globalPosition().toPoint();
     m_pressedButtons = event->buttons();
     Q_EMIT mousePressed();
 }
 
 void HelperWindow::mouseReleaseEvent(QMouseEvent* event)
 {
-    m_latestGlobalMousePos = event->globalPos();
+    m_latestGlobalMousePos = event->globalPosition().toPoint();
     m_pressedButtons = event->buttons();
     Q_EMIT mouseReleased();
 }

--- a/autotests/integration/lockscreen.cpp
+++ b/autotests/integration/lockscreen.cpp
@@ -37,7 +37,7 @@ void unlock()
         QMetaObject::invokeMethod(*it, "requestUnlock");
         return;
     }
-    Q_ASSERT("Did not find 'requestUnlock' method in KSldApp. This should not happen!" == 0);
+    Q_ASSERT("Did not find 'requestUnlock' method in KSldApp. This should not happen!" == nullptr);
 }
 
 }

--- a/autotests/integration/move_resize_window.cpp
+++ b/autotests/integration/move_resize_window.cpp
@@ -135,7 +135,7 @@ TEST_CASE("move resize window", "[win]")
         QCOMPARE(clientStepUserMovedResizedSpy.count(), 1);
         QCOMPARE(windowStepUserMovedResizedSpy.count(), 1);
 
-        win::key_press_event(c, Qt::Key_Down | Qt::ALT);
+        win::key_press_event(c, QKeyCombination(Qt::Key_Down | Qt::ALT).toCombined());
         win::update_move_resize(c, cursor()->pos());
         QCOMPARE(clientStepUserMovedResizedSpy.count(), 2);
         QCOMPARE(windowStepUserMovedResizedSpy.count(), 2);

--- a/autotests/integration/no_crash_glxgears.cpp
+++ b/autotests/integration/no_crash_glxgears.cpp
@@ -44,7 +44,7 @@ TEST_CASE("no crash glxgears", "[xwl],[win]")
     // a fake deco for autotests.
     QPointF pos = decoration->rect().topRight()
         + QPointF(-decoration->borderTop() / 2, decoration->borderTop() / 2);
-    QHoverEvent event(QEvent::HoverMove, pos, pos);
+    QHoverEvent event(QEvent::HoverMove, pos, pos, pos);
     QCoreApplication::instance()->sendEvent(decoration, &event);
 
     // mouse press

--- a/autotests/integration/opengl_shadow.cpp
+++ b/autotests/integration/opengl_shadow.cpp
@@ -530,7 +530,7 @@ TEST_CASE("opengl shadow", "[render]")
             }
         }
 
-        for (const auto& v : qAsConst(mask)) {
+        for (const auto& v : std::as_const(mask)) {
             if (!v) {
                 FAIL("missed a shadow quad");
             }
@@ -623,7 +623,7 @@ TEST_CASE("opengl shadow", "[render]")
         expectedQuads << makeShadowQuad(
             QRectF(-128, 0, 128, 512), 0.0, 128.0 / 257.0, 128.0 / 257.0, 129.0 / 257.0); // left
 
-        for (auto const& expectedQuad : qAsConst(expectedQuads)) {
+        for (auto const& expectedQuad : std::as_const(expectedQuads)) {
             auto it = std::find_if(
                 quads.constBegin(), quads.constEnd(), [&expectedQuad](auto const& quad) {
                     return compareQuads(quad, expectedQuad);
@@ -711,7 +711,7 @@ TEST_CASE("opengl shadow", "[render]")
         WindowQuadList const& quads = shadow->shadowQuads();
         QCOMPARE(quads.count(), expectedQuads.count());
 
-        for (auto const& expectedQuad : qAsConst(expectedQuads)) {
+        for (auto const& expectedQuad : std::as_const(expectedQuads)) {
             auto it = std::find_if(
                 quads.constBegin(), quads.constEnd(), [&expectedQuad](auto const& quad) {
                     return compareQuads(quad, expectedQuad);

--- a/autotests/integration/plasma_surface.cpp
+++ b/autotests/integration/plasma_surface.cpp
@@ -195,8 +195,9 @@ TEST_CASE("plasma surface", "[win]")
         QVERIFY(win::is_dock(panel));
         QCOMPARE(panel->geo.frame, test_data.panel_geo);
         QCOMPARE(panel->hasStrut(), false);
-        QCOMPARE(win::space_window_area(*setup.base->mod.space, win::area_option::maximize, 0, 0),
-                 QRect(0, 0, 1280, 1024));
+        QCOMPARE(
+            win::space_window_area(*setup.base->mod.space, win::area_option::maximize, nullptr, 0),
+            QRect(0, 0, 1280, 1024));
         QCOMPARE(win::get_layer(*panel), win::layer::above);
 
         // create a Window
@@ -342,8 +343,9 @@ TEST_CASE("plasma surface", "[win]")
         QVERIFY(win::is_dock(c));
         QCOMPARE(c->geo.frame, QRect(0, 0, 100, 50));
         REQUIRE(c->hasStrut() == test_data.expected_strut);
-        REQUIRE(win::space_window_area(*setup.base->mod.space, win::area_option::maximize, 0, 0)
-                == test_data.expected_max_area);
+        REQUIRE(
+            win::space_window_area(*setup.base->mod.space, win::area_option::maximize, nullptr, 0)
+            == test_data.expected_max_area);
         REQUIRE(win::get_layer(*c) == test_data.expected_layer);
     }
 

--- a/autotests/integration/qpainter_shadow.cpp
+++ b/autotests/integration/qpainter_shadow.cpp
@@ -544,7 +544,7 @@ TEST_CASE("qpainter shadow", "[render]")
             }
         }
 
-        for (auto const& v : qAsConst(mask)) {
+        for (auto const& v : std::as_const(mask)) {
             if (!v) {
                 FAIL("missed a shadow quad");
             }

--- a/autotests/integration/scripting/screen_edge.cpp
+++ b/autotests/integration/scripting/screen_edge.cpp
@@ -11,11 +11,8 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include "como/render/effect_loader.h"
 #include "como/script/platform.h"
 #include "como/script/script.h"
-#include "como/win/space_reconfigure.h"
-
-#define private public
 #include "como/win/screen_edges.h"
-#undef private
+#include "como/win/space_reconfigure.h"
 
 #include <KConfigGroup>
 #include <catch2/generators/catch_generators.hpp>

--- a/autotests/integration/subspace.cpp
+++ b/autotests/integration/subspace.cpp
@@ -207,8 +207,8 @@ TEST_CASE("subspace", "[win]")
         if (!spy.isEmpty()) {
             auto arguments = spy.takeFirst();
             QCOMPARE(arguments.count(), 2);
-            QCOMPARE(arguments.at(0).type(), QVariant::UInt);
-            QCOMPARE(arguments.at(1).type(), QVariant::UInt);
+            QCOMPARE(arguments.at(0).typeId(), QMetaType::UInt);
+            QCOMPARE(arguments.at(1).typeId(), QMetaType::UInt);
             QCOMPARE(arguments.at(0).toUInt(), count_init_value);
             QCOMPARE(arguments.at(1).toUInt(), test_data.result);
         }

--- a/autotests/integration/transient_placement.cpp
+++ b/autotests/integration/transient_placement.cpp
@@ -498,8 +498,9 @@ TEST_CASE("transient placement", "[win]")
 
         // Placement area still full screen.
         QVERIFY(
-            win::space_window_area(*setup.base->mod.space, win::area_option::placement, 0, 1)
-            == win::space_window_area(*setup.base->mod.space, win::area_option::fullscreen, 0, 1));
+            win::space_window_area(*setup.base->mod.space, win::area_option::placement, nullptr, 1)
+            == win::space_window_area(
+                *setup.base->mod.space, win::area_option::fullscreen, nullptr, 1));
 
         // Now map the panel and placement area is reduced.
         auto dock = render_and_wait_for_shown(surface, QSize(1280, 50), Qt::blue);
@@ -509,8 +510,9 @@ TEST_CASE("transient placement", "[win]")
         QCOMPARE(dock->geo.frame, QRect(0, get_output(0)->geometry().height() - 50, 1280, 50));
         QCOMPARE(dock->hasStrut(), true);
         QVERIFY(
-            win::space_window_area(*setup.base->mod.space, win::area_option::placement, 0, 1)
-            != win::space_window_area(*setup.base->mod.space, win::area_option::fullscreen, 0, 1));
+            win::space_window_area(*setup.base->mod.space, win::area_option::placement, nullptr, 1)
+            != win::space_window_area(
+                *setup.base->mod.space, win::area_option::fullscreen, nullptr, 1));
 
         // Create parent
         auto parentSurface = create_surface();

--- a/autotests/libkwineffects/window_quad_list.cpp
+++ b/autotests/libkwineffects/window_quad_list.cpp
@@ -83,9 +83,9 @@ TEST_CASE("window quad list", "[effect],[unit]")
         auto actual = test_data.orig.makeGrid(test_data.quad_size);
         REQUIRE(actual.count() == test_data.expected_count);
 
-        for (auto const& actualQuad : qAsConst(actual)) {
+        for (auto const& actualQuad : std::as_const(actual)) {
             bool found = false;
-            for (auto const& expectedQuad : qAsConst(test_data.expected)) {
+            for (auto const& expectedQuad : std::as_const(test_data.expected)) {
                 auto vertexTest = [actualQuad, expectedQuad](int index) {
                     auto const& actualVertex = actualQuad[index];
                     auto const& expectedVertex = expectedQuad[index];
@@ -170,9 +170,9 @@ TEST_CASE("window quad list", "[effect],[unit]")
             = test_data.orig.makeRegularGrid(test_data.x_subdivisions, test_data.y_subdivisions);
         REQUIRE(actual.count() == test_data.expected_count);
 
-        for (auto const& actualQuad : qAsConst(actual)) {
+        for (auto const& actualQuad : std::as_const(actual)) {
             bool found = false;
-            for (auto const& expectedQuad : qAsConst(test_data.expected)) {
+            for (auto const& expectedQuad : std::as_const(test_data.expected)) {
                 auto vertexTest = [actualQuad, expectedQuad](int index) {
                     auto const& actualVertex = actualQuad[index];
                     auto const& expectedVertex = expectedQuad[index];

--- a/cmake/modules/CMakeSettings.cmake
+++ b/cmake/modules/CMakeSettings.cmake
@@ -1,0 +1,69 @@
+
+# SPDX-FileCopyrightText: 2024 Roman Gilg <subdiff@gmail.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+################# RPATH handling ##################################
+
+# Set the default RPATH to point to useful locations, namely where the
+# libraries will be installed and the linker search path.
+
+# KDE_INSTALL_LIBDIR comes from previous KDEInstallDirs include.
+if(NOT KDE_INSTALL_LIBDIR)
+   message(FATAL_ERROR "KDE_INSTALL_LIBDIR is not set. Setting one is necessary for using the RPATH settings.")
+endif()
+
+set(_abs_LIB_INSTALL_DIR "${KDE_INSTALL_LIBDIR}")
+
+if (NOT IS_ABSOLUTE "${_abs_LIB_INSTALL_DIR}")
+   set(_abs_LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${_abs_LIB_INSTALL_DIR}")
+endif()
+
+# add our LIB_INSTALL_DIR to the RPATH (but only when it is not one of
+# the standard system link directories - such as /usr/lib)
+list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${_abs_LIB_INSTALL_DIR}" _isSystemLibDir)
+list(FIND CMAKE_CXX_IMPLICIT_LINK_DIRECTORIES      "${_abs_LIB_INSTALL_DIR}" _isSystemCxxLibDir)
+list(FIND CMAKE_C_IMPLICIT_LINK_DIRECTORIES        "${_abs_LIB_INSTALL_DIR}" _isSystemCLibDir)
+if("${_isSystemLibDir}" STREQUAL "-1"  AND  "${_isSystemCxxLibDir}" STREQUAL "-1"  AND  "${_isSystemCLibDir}" STREQUAL "-1")
+   set(CMAKE_INSTALL_RPATH "${_abs_LIB_INSTALL_DIR}")
+endif()
+
+# Append directories in the linker search path (but outside the project)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+################ Build settings ###########################
+
+# Always include srcdir and builddir in include path
+# This saves typing ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} in about every subdir
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# put the include dirs which are in the source or build tree before all other include dirs, so the
+# headers in the sources are preferred over the already installed ones
+set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
+
+# Add the src and build dir to the BUILD_INTERFACE include directories of all targets. Similar to
+# CMAKE_INCLUDE_CURRENT_DIR, but transitive.
+set(CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE ON)
+
+# When a shared library changes, but its includes do not, don't relink all dependencies. It is not
+# needed.
+set(CMAKE_LINK_DEPENDS_NO_SHARED ON)
+
+# Default to shared libs, if no type is explicitly given to add_library().
+set(BUILD_SHARED_LIBS TRUE CACHE BOOL "If enabled, shared libs will be built by default, otherwise static libs")
+
+set(CMAKE_AUTOMOC ON)
+
+# Enable autorcc and in cmake so qrc files get generated..
+set(CMAKE_AUTORCC ON)
+
+# By default, don't put a prefix on MODULE targets. add_library(MODULE) is basically for plugin
+# targets, and in KDE plugins don't have a prefix.
+set(CMAKE_SHARED_MODULE_PREFIX "")
+
+# All executables are built into a toplevel "bin" dir, making it possible to find helper binaries,
+# and to find uninstalled plugins (provided that you use kcoreaddons_add_plugin() or set
+# LIBRARY_OUTPUT_DIRECTORY as documented on [1].
+# [1] https://community.kde.org/Guidelines_and_HOWTOs/Making_apps_run_uninstalled)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")

--- a/como/base/CMakeLists.txt
+++ b/como/base/CMakeLists.txt
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 add_library(base SHARED)
-target_compile_options (base PUBLIC -fexceptions)
-
 target_link_libraries(base
   PUBLIC
     utils

--- a/como/base/x11/xcb/extensions.cpp
+++ b/como/base/x11/xcb/extensions.cpp
@@ -19,7 +19,10 @@
 #include <xcb/sync.h>
 #include <xcb/xfixes.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
 #define explicit cpp_explicit_compat
+#pragma clang diagnostic pop
 #include <xcb/xkb.h>
 #undef explicit
 

--- a/como/base/x11/xcb/wrapper.h
+++ b/como/base/x11/xcb/wrapper.h
@@ -232,7 +232,7 @@ public:
     inline bool is_null() const
     {
         const_cast<abstract_wrapper*>(this)->get_reply();
-        return m_reply == NULL;
+        return m_reply == nullptr;
     }
     inline operator bool()
     {

--- a/como/debug/console/console.cpp
+++ b/como/debug/console/console.cpp
@@ -33,7 +33,7 @@ console_delegate::~console_delegate() = default;
 QString console_delegate::displayText(const QVariant& value, const QLocale& locale) const
 {
     // See Qt docs. Return value of QVariant::type() should be interpreted as QMetaType.
-    switch (static_cast<QMetaType::Type>(value.type())) {
+    switch (value.typeId()) {
     case QMetaType::QPoint: {
         const QPoint p = value.toPoint();
         return QStringLiteral("%1,%2").arg(p.x()).arg(p.y());

--- a/como/debug/console/wayland/input_filter.h
+++ b/como/debug/console/wayland/input_filter.h
@@ -376,7 +376,9 @@ public:
         auto text = QString(s_hr) + QString(s_tableStart) + tableHeaderRow(i18n("Tablet Tool"))
             + tableRow(i18n("EventType"), typeString)
             + tableRow(i18n("Position"),
-                       QStringLiteral("%1,%2").arg(event->pos().x()).arg(event->pos().y()))
+                       QStringLiteral("%1,%2")
+                           .arg(event->position().toPoint().x())
+                           .arg(event->position().toPoint().y()))
             + tableRow(i18n("Tilt"),
                        QStringLiteral("%1,%2").arg(event->xTilt()).arg(event->yTilt()))
             + tableRow(i18n("Rotation"), QString::number(event->rotation()))

--- a/como/debug/support_info.h
+++ b/como/debug/support_info.h
@@ -230,18 +230,18 @@ QString get_support_info(Space const& space)
         support.append(QStringLiteral("\nLoaded Effects:\n"));
         support.append(QStringLiteral("---------------\n"));
         auto const& loaded_effects = effects->loadedEffects();
-        for (auto const& effect : qAsConst(loaded_effects)) {
+        for (auto const& effect : std::as_const(loaded_effects)) {
             support.append(effect + QStringLiteral("\n"));
         }
         support.append(QStringLiteral("\nCurrently Active Effects:\n"));
         support.append(QStringLiteral("-------------------------\n"));
         auto const& active_effects = effects->activeEffects();
-        for (auto const& effect : qAsConst(active_effects)) {
+        for (auto const& effect : std::as_const(active_effects)) {
             support.append(effect + QStringLiteral("\n"));
         }
         support.append(QStringLiteral("\nEffect Settings:\n"));
         support.append(QStringLiteral("----------------\n"));
-        for (auto const& effect : qAsConst(loaded_effects)) {
+        for (auto const& effect : std::as_const(loaded_effects)) {
             support.append(effects->supportInformation(effect));
             support.append(QStringLiteral("\n"));
         }

--- a/como/debug/support_info.h
+++ b/como/debug/support_info.h
@@ -94,7 +94,7 @@ QString get_support_info(Space const& space)
 
     auto const metaOptions = space.base.mod.script->options->metaObject();
     auto printProperty = [](const QVariant& variant) {
-        if (variant.type() == QVariant::Size) {
+        if (variant.typeId() == QMetaType::QSize) {
             const QSize& s = variant.toSize();
             return QStringLiteral("%1x%2")
                 .arg(QString::number(s.width()))

--- a/como/input/filters/decoration_event.h
+++ b/como/input/filters/decoration_event.h
@@ -89,7 +89,7 @@ public:
                 auto const global_pos = this->redirect.globalPointer();
                 auto const local_pos = global_pos - win->geo.pos();
 
-                auto qt_event = QHoverEvent(QEvent::HoverMove, local_pos, local_pos);
+                auto qt_event = QHoverEvent(QEvent::HoverMove, local_pos, local_pos, local_pos);
                 QCoreApplication::instance()->sendEvent(decoration->decoration(), &qt_event);
                 win::process_decoration_move(win, local_pos.toPoint(), global_pos.toPoint());
                 return true;
@@ -163,29 +163,32 @@ public:
 
         assert(this->redirect.touch->focus.deco.window);
 
-        return std::visit(
-            overload{[&](auto&& win) {
-                this->redirect.touch->setDecorationPressId(event.id);
-                m_lastGlobalTouchPos = event.pos;
-                m_lastLocalTouchPos = event.pos - win->geo.pos();
+        return std::visit(overload{[&](auto&& win) {
+                              this->redirect.touch->setDecorationPressId(event.id);
+                              m_lastGlobalTouchPos = event.pos;
+                              m_lastLocalTouchPos = event.pos - win->geo.pos();
 
-                QHoverEvent hoverEvent(QEvent::HoverMove, m_lastLocalTouchPos, m_lastLocalTouchPos);
-                QCoreApplication::sendEvent(decoration->decoration(), &hoverEvent);
+                              QHoverEvent hoverEvent(QEvent::HoverMove,
+                                                     m_lastLocalTouchPos,
+                                                     m_lastLocalTouchPos,
+                                                     m_lastLocalTouchPos);
+                              QCoreApplication::sendEvent(decoration->decoration(), &hoverEvent);
 
-                QMouseEvent e(QEvent::MouseButtonPress,
-                              m_lastLocalTouchPos,
-                              event.pos,
-                              Qt::LeftButton,
-                              Qt::LeftButton,
-                              xkb::get_active_keyboard_modifiers(this->redirect.platform));
-                e.setAccepted(false);
-                QCoreApplication::sendEvent(decoration->decoration(), &e);
-                if (!e.isAccepted()) {
-                    win::process_decoration_button_press(win, &e, false);
-                }
-                return true;
-            }},
-            *this->redirect.touch->focus.deco.window);
+                              QMouseEvent e(
+                                  QEvent::MouseButtonPress,
+                                  m_lastLocalTouchPos,
+                                  event.pos,
+                                  Qt::LeftButton,
+                                  Qt::LeftButton,
+                                  xkb::get_active_keyboard_modifiers(this->redirect.platform));
+                              e.setAccepted(false);
+                              QCoreApplication::sendEvent(decoration->decoration(), &e);
+                              if (!e.isAccepted()) {
+                                  win::process_decoration_button_press(win, &e, false);
+                              }
+                              return true;
+                          }},
+                          *this->redirect.touch->focus.deco.window);
     }
 
     bool touch_motion(touch_motion_event const& event) override
@@ -210,8 +213,10 @@ public:
                               m_lastGlobalTouchPos = event.pos;
                               m_lastLocalTouchPos = event.pos - win->geo.pos();
 
-                              QHoverEvent e(
-                                  QEvent::HoverMove, m_lastLocalTouchPos, m_lastLocalTouchPos);
+                              QHoverEvent e(QEvent::HoverMove,
+                                            m_lastLocalTouchPos,
+                                            m_lastLocalTouchPos,
+                                            m_lastLocalTouchPos);
                               QCoreApplication::instance()->sendEvent(decoration->decoration(), &e);
                               win::process_decoration_move(
                                   win, m_lastLocalTouchPos.toPoint(), event.pos.toPoint());
@@ -251,7 +256,7 @@ public:
         std::visit(overload{[&](auto&& win) { win::process_decoration_button_release(win, &e); }},
                    *this->redirect.touch->focus.deco.window);
 
-        QHoverEvent leaveEvent(QEvent::HoverLeave, QPointF(), QPointF());
+        QHoverEvent leaveEvent(QEvent::HoverLeave, QPointF(), QPointF(), QPointF());
         QCoreApplication::sendEvent(decoration->decoration(), &leaveEvent);
 
         m_lastGlobalTouchPos = QPointF();

--- a/como/input/filters/fake_tablet.h
+++ b/como/input/filters/fake_tablet.h
@@ -36,7 +36,7 @@ public:
         switch (event->type()) {
         case QEvent::TabletMove:
         case QEvent::TabletEnterProximity:
-            this->redirect.pointer->processMotion(event->globalPosF(), event->timestamp());
+            this->redirect.pointer->processMotion(event->globalPosition(), event->timestamp());
             break;
         case QEvent::TabletPress:
             this->redirect.pointer->process_button(get_event(button_state::pressed));

--- a/como/input/filters/move_resize.h
+++ b/como/input/filters/move_resize.h
@@ -59,18 +59,20 @@ public:
 
     void process_key_press(typename Redirect::window_t window, key_event const& event)
     {
-        std::visit(overload{[&](auto&& win) {
-                       win::key_press_event(
-                           win,
-                           key_to_qt_key(event.keycode, event.base.dev->xkb.get())
-                               | xkb::get_active_keyboard_modifiers(this->redirect.platform));
+        std::visit(
+            overload{[&](auto&& win) {
+                win::key_press_event(
+                    win,
+                    QKeyCombination(xkb::get_active_keyboard_modifiers(this->redirect.platform),
+                                    key_to_qt_key(event.keycode, event.base.dev->xkb.get()))
+                        .toCombined());
 
-                       if (win::is_move(win) || win::is_resize(win)) {
-                           // Only update if mode didn't end.
-                           win::update_move_resize(win, this->redirect.globalPointer());
-                       }
-                   }},
-                   window);
+                if (win::is_move(win) || win::is_resize(win)) {
+                    // Only update if mode didn't end.
+                    win::update_move_resize(win, this->redirect.globalPointer());
+                }
+            }},
+            window);
     }
 
     bool key(key_event const& event) override

--- a/como/input/filters/tabbox.h
+++ b/como/input/filters/tabbox.h
@@ -71,7 +71,9 @@ public:
 
         if (event.state == key_state::pressed) {
             auto mods = xkb::get_active_keyboard_modifiers(this->redirect.platform);
-            tabbox->key_press(mods | key_to_qt_key(event.keycode, event.base.dev->xkb.get()));
+            tabbox->key_press(
+                QKeyCombination(mods, key_to_qt_key(event.keycode, event.base.dev->xkb.get()))
+                    .toCombined());
         } else if (xkb::get_active_keyboard_modifiers_relevant_for_global_shortcuts(
                        this->redirect.platform)
                    == Qt::NoModifier) {
@@ -89,7 +91,9 @@ public:
         }
 
         auto mods = xkb::get_active_keyboard_modifiers(this->redirect.platform);
-        tabbox->key_press(mods | key_to_qt_key(event.keycode, event.base.dev->xkb.get()));
+        tabbox->key_press(
+            QKeyCombination(mods, key_to_qt_key(event.keycode, event.base.dev->xkb.get()))
+                .toCombined());
         return true;
     }
 

--- a/como/input/wayland/global_shortcuts_manager.cpp
+++ b/como/input/wayland/global_shortcuts_manager.cpp
@@ -94,7 +94,7 @@ void global_shortcuts_manager::objectDeleted(QObject* object)
 
 bool global_shortcuts_manager::shortcut_exists(global_shortcut const& sc)
 {
-    for (const auto& cs : qAsConst(m_shortcuts)) {
+    for (const auto& cs : std::as_const(m_shortcuts)) {
         if (sc.shortcut() == cs.shortcut()) {
             return false;
         }

--- a/como/input/wayland/platform.h
+++ b/como/input/wayland/platform.h
@@ -151,7 +151,7 @@ public:
 
     bool are_mod_keys_depressed(QKeySequence const& seq) const
     {
-        const int mod = seq[seq.count() - 1] & Qt::KeyboardModifierMask;
+        auto const mod = seq[seq.count() - 1].toCombined() & Qt::KeyboardModifierMask;
         auto const mods = xkb::get_active_keyboard_modifiers_relevant_for_global_shortcuts(*this);
 
         if ((mod & Qt::SHIFT) && mods.testFlag(Qt::ShiftModifier)) {

--- a/como/input/wayland/pointer_redirect.h
+++ b/como/input/wayland/pointer_redirect.h
@@ -585,7 +585,7 @@ public:
         redirect->space.focusMousePos = position().toPoint();
 
         // send leave event to decoration
-        QHoverEvent event(QEvent::HoverLeave, QPointF(), QPointF());
+        QHoverEvent event(QEvent::HoverLeave, QPointF(), QPointF(), QPointF());
         QCoreApplication::instance()->sendEvent(focus.deco.client->decoration(), &event);
 
         focus.deco = {};
@@ -600,7 +600,7 @@ public:
         redirect->platform.base.server->seat()->pointers().set_focused_surface(nullptr);
 
         auto pos = m_pos - now.client()->geo.pos();
-        QHoverEvent event(QEvent::HoverEnter, pos, pos);
+        QHoverEvent event(QEvent::HoverEnter, pos, pos, pos);
         QCoreApplication::instance()->sendEvent(now.decoration(), &event);
         win::process_decoration_move(now.client(), pos.toPoint(), m_pos.toPoint());
 
@@ -637,7 +637,7 @@ public:
                                // position of window did not change, we need to send
                                // HoverMotion manually
                                QPointF const p = m_pos - win->geo.pos();
-                               QHoverEvent event(QEvent::HoverMove, p, p);
+                               QHoverEvent event(QEvent::HoverMove, p, p, p);
                                QCoreApplication::instance()->sendEvent(deco->decoration(), &event);
                            }},
                            *focus.deco.window);
@@ -814,7 +814,7 @@ private:
             device_redirect_set_internal_window(this, nullptr);
         }
         if (focus.deco.client) {
-            QHoverEvent event(QEvent::HoverLeave, QPointF(), QPointF());
+            QHoverEvent event(QEvent::HoverLeave, QPointF(), QPointF(), QPointF());
             QCoreApplication::instance()->sendEvent(focus.deco.client->decoration(), &event);
             device_redirect_unset_deco(this);
         }

--- a/como/input/x11/platform.h
+++ b/como/input/x11/platform.h
@@ -106,7 +106,7 @@ public:
     {
         uint rgKeySyms[10];
         int nKeySyms = 0;
-        int mod = seq[seq.count() - 1] & Qt::KeyboardModifierMask;
+        auto mod = seq[seq.count() - 1].toCombined() & Qt::KeyboardModifierMask;
 
         if (mod & Qt::SHIFT) {
             rgKeySyms[nKeySyms++] = XK_Shift_L;

--- a/como/input/x11/xkb.h
+++ b/como/input/x11/xkb.h
@@ -9,7 +9,10 @@
 #include <como/input/logging.h>
 #include <como/input/xkb/keymap.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wkeyword-macro"
 #define explicit cpp_explicit_compat
+#pragma clang diagnostic pop
 #include <xcb/xkb.h>
 #undef explicit
 #include <xkbcommon/xkbcommon-x11.h>

--- a/como/render/backend/wlroots/wlr_non_owning_data_buffer.h
+++ b/como/render/backend/wlroots/wlr_non_owning_data_buffer.h
@@ -59,8 +59,8 @@ static inline wlr_non_owning_data_buffer* wlr_non_owning_data_buffer_create(uint
 
     auto buffer
         = static_cast<wlr_non_owning_data_buffer*>(calloc(1, sizeof(wlr_non_owning_data_buffer)));
-    if (buffer == NULL) {
-        return NULL;
+    if (!buffer) {
+        return nullptr;
     }
 
     wlr_buffer_init(&buffer->base, &wlr_non_owning_data_buffer_impl, width, height);

--- a/como/render/effect/basic_effect_loader.cpp
+++ b/como/render/effect/basic_effect_loader.cpp
@@ -21,7 +21,7 @@ load_effect_flags basic_effect_loader::readConfig(QString const& effectName,
     Q_ASSERT(m_config);
     KConfigGroup plugins(m_config, QStringLiteral("Plugins"));
 
-    auto const key = effectName + QStringLiteral("Enabled");
+    auto const key = QString(effectName + QStringLiteral("Enabled"));
 
     // do we have a key for the effect?
     if (plugins.hasKey(key)) {

--- a/como/render/effect/integration.h
+++ b/como/render/effect/integration.h
@@ -18,7 +18,7 @@ void setup_effect_screen_geometry_changes(EffectIntegrator& effi)
     QObject::connect(&effi.effects, &Effects::screenGeometryChanged, &effi.effects, [&] {
         effi.reset();
         auto const& stacking_order = effi.effects.stackingOrder();
-        for (auto const& window : qAsConst(stacking_order)) {
+        for (auto const& window : std::as_const(stacking_order)) {
             effi.update(*window);
         }
     });

--- a/como/render/effect/interface/offscreen_quick_view.cpp
+++ b/como/render/effect/interface/offscreen_quick_view.cpp
@@ -329,7 +329,7 @@ void OffscreenQuickView::forwardMouseEvent(QEvent* e)
         QHoverEvent* he = static_cast<QHoverEvent*>(e);
         auto const widgetPos = d->m_view->mapFromGlobal(he->position());
         const QPointF oldWidgetPos = d->m_view->mapFromGlobal(he->oldPos());
-        QHoverEvent cloneEvent(he->type(), widgetPos, oldWidgetPos, he->modifiers());
+        QHoverEvent cloneEvent(he->type(), widgetPos, widgetPos, oldWidgetPos, he->modifiers());
         QCoreApplication::sendEvent(d->m_view, &cloneEvent);
         e->setAccepted(cloneEvent.isAccepted());
         return;

--- a/como/render/effect/interface/offscreen_quick_view.cpp
+++ b/como/render/effect/interface/offscreen_quick_view.cpp
@@ -611,16 +611,16 @@ void OffscreenQuickScene::setSource(const QUrl& source, const QVariantMap& initi
 
     d->quickItem.reset();
 
-    QScopedPointer<QObject> qmlObject(
+    auto qmlObject = std::make_unique<QObject>(
         d->qmlComponent->createWithInitialProperties(initialProperties));
-    QQuickItem* item = qobject_cast<QQuickItem*>(qmlObject.data());
+    auto item = qobject_cast<QQuickItem*>(qmlObject.get());
     if (!item) {
         qCWarning(KWIN_CORE) << "Root object of effect quick view" << source
                              << "is not a QQuickItem";
         return;
     }
 
-    qmlObject.take();
+    qmlObject.release();
     d->quickItem.reset(item);
 
     item->setParentItem(contentItem());

--- a/como/render/effect/interface/offscreen_quick_view.cpp
+++ b/como/render/effect/interface/offscreen_quick_view.cpp
@@ -311,9 +311,9 @@ void OffscreenQuickView::forwardMouseEvent(QEvent* e)
             if (doubleClick) {
                 d->lastMousePressButton = Qt::NoButton;
                 QMouseEvent doubleClickEvent(QEvent::MouseButtonDblClick,
-                                             me->localPos(),
-                                             me->windowPos(),
-                                             me->screenPos(),
+                                             me->position().toPoint(),
+                                             me->scenePosition().toPoint(),
+                                             me->globalPosition(),
                                              me->button(),
                                              me->buttons(),
                                              me->modifiers());
@@ -327,7 +327,7 @@ void OffscreenQuickView::forwardMouseEvent(QEvent* e)
     case QEvent::HoverLeave:
     case QEvent::HoverMove: {
         QHoverEvent* he = static_cast<QHoverEvent*>(e);
-        const QPointF widgetPos = d->m_view->mapFromGlobal(he->pos());
+        auto const widgetPos = d->m_view->mapFromGlobal(he->position());
         const QPointF oldWidgetPos = d->m_view->mapFromGlobal(he->oldPos());
         QHoverEvent cloneEvent(he->type(), widgetPos, oldWidgetPos, he->modifiers());
         QCoreApplication::sendEvent(d->m_view, &cloneEvent);

--- a/como/render/effect/interface/paint_clipper.cpp
+++ b/como/render/effect/interface/paint_clipper.cpp
@@ -58,7 +58,7 @@ QRegion PaintClipper::paintArea()
     Q_ASSERT(areas != nullptr); // can be called only with clip() == true
     const QSize& s = effects->virtualScreenSize();
     QRegion ret(0, 0, s.width(), s.height());
-    for (const QRegion& r : qAsConst(*areas)) {
+    for (const QRegion& r : std::as_const(*areas)) {
         ret &= r;
     }
     return ret;

--- a/como/render/effect/interface/quick_scene.cpp
+++ b/como/render/effect/interface/quick_scene.cpp
@@ -550,7 +550,7 @@ void QuickSceneEffect::windowInputMouseEvent(QEvent* event)
     QPoint globalPosition;
     if (QMouseEvent* mouseEvent = dynamic_cast<QMouseEvent*>(event)) {
         buttons = mouseEvent->buttons();
-        globalPosition = mouseEvent->globalPos();
+        globalPosition = mouseEvent->globalPosition().toPoint();
     } else if (QWheelEvent* wheelEvent = dynamic_cast<QWheelEvent*>(event)) {
         buttons = wheelEvent->buttons();
         globalPosition = wheelEvent->globalPosition().toPoint();

--- a/como/render/effect/interface/window_quad.cpp
+++ b/como/render/effect/interface/window_quad.cpp
@@ -256,7 +256,7 @@ WindowQuadList WindowQuadList::makeGrid(int maxQuadSize) const
     double top = first().top();
     double bottom = first().bottom();
 
-    for (auto const& quad : qAsConst(*this)) {
+    for (auto const& quad : std::as_const(*this)) {
 #if !defined(QT_NO_DEBUG)
         if (quad.isTransformed())
             qFatal("Splitting quads is allowed only in pre-paint calls!");
@@ -455,10 +455,10 @@ void WindowQuadList::makeArrays(float** vertices,
 
 WindowQuadList WindowQuadList::select(WindowQuadType type) const
 {
-    for (auto const& q : qAsConst(*this)) {
+    for (auto const& q : std::as_const(*this)) {
         if (q.type() != type) { // something else than ones to select, make a copy and filter
             WindowQuadList ret;
-            for (auto const& q : qAsConst(*this)) {
+            for (auto const& q : std::as_const(*this)) {
                 if (q.type() == type)
                     ret.append(q);
             }
@@ -473,7 +473,7 @@ WindowQuadList WindowQuadList::filterOut(WindowQuadType type) const
     for (const WindowQuad& q : *this) {
         if (q.type() == type) { // something to filter out, make a copy and filter
             WindowQuadList ret;
-            for (auto const& q : qAsConst(*this)) {
+            for (auto const& q : std::as_const(*this)) {
                 if (q.type() != type)
                     ret.append(q);
             }

--- a/como/render/effect/screen_impl.h
+++ b/como/render/effect/screen_impl.h
@@ -87,7 +87,7 @@ template<typename Effects, typename Output>
 effect_screen_impl<Output>* get_effect_screen(Effects const& effects, Output const& output)
 {
     auto const& screens = effects.screens();
-    for (auto&& eff_screen : qAsConst(screens)) {
+    for (auto&& eff_screen : std::as_const(screens)) {
         auto eff_screen_impl = static_cast<effect_screen_impl<Output>*>(eff_screen);
         if (&output == eff_screen_impl->platformOutput()) {
             return eff_screen_impl;

--- a/como/render/effects.cpp
+++ b/como/render/effects.cpp
@@ -34,7 +34,7 @@ effects_handler_wrap::~effects_handler_wrap()
 
 void effects_handler_wrap::unloadAllEffects()
 {
-    for (const EffectPair& pair : qAsConst(loaded_effects)) {
+    for (const EffectPair& pair : std::as_const(loaded_effects)) {
         destroyEffect(pair.second);
     }
 
@@ -323,7 +323,7 @@ bool effects_handler_wrap::checkInputWindowEvent(QMouseEvent* e)
     if (m_grabbedMouseEffects.isEmpty()) {
         return false;
     }
-    for (auto const& effect : qAsConst(m_grabbedMouseEffects)) {
+    for (auto const& effect : std::as_const(m_grabbedMouseEffects)) {
         effect->windowInputMouseEvent(e);
     }
     return true;
@@ -334,7 +334,7 @@ bool effects_handler_wrap::checkInputWindowEvent(QWheelEvent* e)
     if (m_grabbedMouseEffects.isEmpty()) {
         return false;
     }
-    for (auto const& effect : qAsConst(m_grabbedMouseEffects)) {
+    for (auto const& effect : std::as_const(m_grabbedMouseEffects)) {
         effect->windowInputMouseEvent(e);
     }
     return true;

--- a/como/render/effects.h
+++ b/como/render/effects.h
@@ -830,7 +830,7 @@ public:
 
     EffectScreen* findScreen(const QString& name) const override
     {
-        for (EffectScreen* screen : qAsConst(m_effectScreens)) {
+        for (EffectScreen* screen : std::as_const(m_effectScreens)) {
             if (screen->name() == name) {
                 return screen;
             }

--- a/como/render/gl/window.h
+++ b/como/render/gl/window.h
@@ -114,7 +114,7 @@ public:
         auto content_ids = std::vector<int>{last_content_id};
 
         // Split the quads into separate lists for each type
-        for (auto const& quad : qAsConst(data.quads)) {
+        for (auto const& quad : std::as_const(data.quads)) {
             switch (quad.type()) {
             case WindowQuadShadow:
                 quads[ShadowLeaf].append(quad);
@@ -147,7 +147,7 @@ public:
                 quads.resize(quads.size() + 1);
                 auto const& old_content_rect = previous->win_integration->get_contents_rect();
 
-                for (auto const& quad : qAsConst(quads[ContentLeaf])) {
+                for (auto const& quad : std::as_const(quads[ContentLeaf])) {
                     if (quad.id() != static_cast<int>(this->id())) {
                         // We currently only do this for the main window and not annexed children
                         // that means we can skip from here on.
@@ -410,7 +410,7 @@ private:
             auto const filterRegion = data.paint.region.translated(-win_pos.x(), -win_pos.y());
 
             // split all quads in bounding rect with the actual rects in the region
-            for (auto const& quad : qAsConst(data.quads)) {
+            for (auto const& quad : std::as_const(data.quads)) {
                 for (auto const& r : filterRegion) {
                     QRectF const rf(r);
                     QRectF const quadRect(QPointF(quad.left(), quad.top()),

--- a/como/render/x11/support_properties.h
+++ b/como/render/x11/support_properties.h
@@ -40,7 +40,7 @@ void delete_unused_support_properties(Compositor& comp)
         return;
     }
 
-    for (auto const& atom : qAsConst(comp.unused_support_properties)) {
+    for (auto const& atom : std::as_const(comp.unused_support_properties)) {
         // remove property from root window
         xcb_delete_property(con, comp.base.x11_data.root_window, atom);
     }

--- a/como/script/effect.cpp
+++ b/como/script/effect.cpp
@@ -695,7 +695,7 @@ bool effect::borderActivated(ElectricBorder edge)
         return false;
     }
 
-    for (auto const& callback : qAsConst(it->second)) {
+    for (auto const& callback : std::as_const(it->second)) {
         QJSValue(callback).call();
     }
     return true;

--- a/como/script/platform.cpp
+++ b/como/script/platform.cpp
@@ -151,7 +151,7 @@ bool platform_wrap::isScriptLoaded(const QString& pluginName) const
 abstract_script* platform_wrap::findScript(const QString& pluginName) const
 {
     QMutexLocker locker(m_scriptsLock.data());
-    for (auto const& script : qAsConst(scripts)) {
+    for (auto const& script : std::as_const(scripts)) {
         if (script->pluginName() == pluginName) {
             return script;
         }
@@ -162,7 +162,7 @@ abstract_script* platform_wrap::findScript(const QString& pluginName) const
 bool platform_wrap::unloadScript(const QString& pluginName)
 {
     QMutexLocker locker(m_scriptsLock.data());
-    for (auto const& script : qAsConst(scripts)) {
+    for (auto const& script : std::as_const(scripts)) {
         if (script->pluginName() == pluginName) {
             script->deleteLater();
             return true;

--- a/como/script/platform.h
+++ b/como/script/platform.h
@@ -236,7 +236,7 @@ public:
         assert(window_it != w_wins.cend());
 
         QList<QAction*> actions;
-        for (auto s : qAsConst(scripts)) {
+        for (auto s : std::as_const(scripts)) {
             // TODO: Allow declarative scripts to add their own user actions.
             if (auto script = qobject_cast<scripting::script*>(s)) {
                 actions << script->actionsForUserActionMenu(*window_it, parent);

--- a/como/script/script.cpp
+++ b/como/script/script.cpp
@@ -312,7 +312,7 @@ void script::callDBus(const QString& service,
 
     QVariantList dbusArguments;
     dbusArguments.reserve(jsArguments.count());
-    for (const QJSValue& jsArgument : qAsConst(jsArguments)) {
+    for (const QJSValue& jsArgument : std::as_const(jsArguments)) {
         dbusArguments << jsArgument.toVariant();
     }
 
@@ -451,7 +451,7 @@ QList<QAction*> script::actionsForUserActionMenu(window* window, QMenu* parent)
     QList<QAction*> actions;
     actions.reserve(m_userActionsMenuCallbacks.count());
 
-    for (QJSValue callback : qAsConst(m_userActionsMenuCallbacks)) {
+    for (QJSValue callback : std::as_const(m_userActionsMenuCallbacks)) {
         QJSValue result = callback.call({m_engine->toScriptValue(window)});
         if (result.isError()) {
             continue;

--- a/como/script/window_thumbnail_item.cpp
+++ b/como/script/window_thumbnail_item.cpp
@@ -200,7 +200,7 @@ void window_thumbnail_item::destroyOffscreenTexture()
 
         if (m_acquireFence) {
             glDeleteSync(m_acquireFence);
-            m_acquireFence = 0;
+            m_acquireFence = nullptr;
         }
         effects->doneOpenGLContextCurrent();
     }
@@ -216,7 +216,7 @@ QSGNode* window_thumbnail_item::updatePaintNode(QSGNode* oldNode, QQuickItem::Up
     if (m_acquireFence) {
         glClientWaitSync(m_acquireFence, GL_SYNC_FLUSH_COMMANDS_BIT, 5000);
         glDeleteSync(m_acquireFence);
-        m_acquireFence = 0;
+        m_acquireFence = nullptr;
     }
 
     if (!m_provider) {

--- a/como/script/window_thumbnail_item.cpp
+++ b/como/script/window_thumbnail_item.cpp
@@ -337,7 +337,7 @@ void window_thumbnail_item::updateImplicitSize()
 QImage window_thumbnail_item::fallbackImage() const
 {
     if (m_client) {
-        return m_client->icon().pixmap(window(), boundingRect().size().toSize()).toImage();
+        return m_client->icon().pixmap(boundingRect().size().toSize()).toImage();
     }
     return QImage();
 }
@@ -356,7 +356,7 @@ QRectF window_thumbnail_item::paintedRect() const
         return QRectF();
     }
     if (!m_offscreenTexture) {
-        auto const iconSize = m_client->icon().actualSize(window(), boundingRect().size().toSize());
+        auto const iconSize = m_client->icon().actualSize(boundingRect().size().toSize());
         return centeredSize(boundingRect(), iconSize);
     }
 

--- a/como/script/window_thumbnail_item.h
+++ b/como/script/window_thumbnail_item.h
@@ -76,7 +76,7 @@ private:
     mutable ThumbnailTextureProvider* m_provider = nullptr;
     QSharedPointer<GLTexture> m_offscreenTexture;
     QScopedPointer<GLFramebuffer> m_offscreenTarget;
-    GLsync m_acquireFence = 0;
+    GLsync m_acquireFence{nullptr};
     qreal m_devicePixelRatio = 1;
 
     QMetaObject::Connection render_notifier;

--- a/como/win/deco_input.h
+++ b/como/win/deco_input.h
@@ -72,7 +72,7 @@ bool process_decoration_button_press(Win* win, QMouseEvent* event, bool ignoreMe
     // In the new API the decoration may process the menu action to display an inactive tab's menu.
     // If the event is unhandled then the core will create one for the active window in the group.
     if (!ignoreMenu || com != mouse_cmd::operations_menu) {
-        perform_mouse_command(*win, com, event->globalPos());
+        perform_mouse_command(*win, com, event->globalPosition().toPoint());
     }
 
     // Return events that should be passed to the decoration in the new API.

--- a/como/win/input/gestures.cpp
+++ b/como/win/input/gestures.cpp
@@ -123,7 +123,7 @@ int gesture_recognizer::startSwipeGesture(uint fingerCount,
         return 0;
     }
     int count = 0;
-    for (swipe_gesture* gesture : qAsConst(m_swipeGestures)) {
+    for (swipe_gesture* gesture : std::as_const(m_swipeGestures)) {
         if (gesture->minimumFingerCountIsRelevant()) {
             if (gesture->minimumFingerCount() > fingerCount) {
                 continue;
@@ -253,10 +253,10 @@ void gesture_recognizer::updateSwipeGesture(const QSizeF& delta)
 
 void gesture_recognizer::cancelActiveGestures()
 {
-    for (auto g : qAsConst(m_activeSwipeGestures)) {
+    for (auto g : std::as_const(m_activeSwipeGestures)) {
         Q_EMIT g->cancelled();
     }
-    for (auto g : qAsConst(m_activePinchGestures)) {
+    for (auto g : std::as_const(m_activePinchGestures)) {
         Q_EMIT g->cancelled();
     }
     m_activeSwipeGestures.clear();
@@ -277,7 +277,7 @@ void gesture_recognizer::cancelSwipeGesture()
 void gesture_recognizer::endSwipeGesture()
 {
     const QSizeF delta = m_currentDelta;
-    for (auto g : qAsConst(m_activeSwipeGestures)) {
+    for (auto g : std::as_const(m_activeSwipeGestures)) {
         if (static_cast<swipe_gesture*>(g)->minimumDeltaReached(delta)) {
             Q_EMIT g->triggered();
         } else {
@@ -297,7 +297,7 @@ int gesture_recognizer::startPinchGesture(uint fingerCount)
     if (!m_activeSwipeGestures.isEmpty() || !m_activePinchGestures.isEmpty()) {
         return 0;
     }
-    for (pinch_gesture* gesture : qAsConst(m_pinchGestures)) {
+    for (pinch_gesture* gesture : std::as_const(m_pinchGestures)) {
         if (gesture->minimumFingerCountIsRelevant()) {
             if (gesture->minimumFingerCount() > fingerCount) {
                 continue;
@@ -364,7 +364,7 @@ void gesture_recognizer::cancelPinchGesture()
 
 void gesture_recognizer::endPinchGesture() // because fingers up
 {
-    for (auto g : qAsConst(m_activePinchGestures)) {
+    for (auto g : std::as_const(m_activePinchGestures)) {
         if (g->minimumScaleDeltaReached(m_currentScale)) {
             Q_EMIT g->triggered();
         } else {

--- a/como/win/input/global_shortcut.h
+++ b/como/win/input/global_shortcut.h
@@ -107,7 +107,7 @@ std::vector<KeyboardShortcut> get_internal_shortcuts(QList<ShortcutInfo> const& 
     std::vector<KeyboardShortcut> ret;
     ret.reserve(list.size());
 
-    for (auto&& el : qAsConst(list)) {
+    for (auto&& el : std::as_const(list)) {
         auto const keys = el.keys();
         auto const seq = keys.empty() ? QKeySequence() : keys.front();
         ret.push_back(KeyboardShortcut{.sequence = seq,

--- a/como/win/rules/book.cpp
+++ b/como/win/rules/book.cpp
@@ -67,7 +67,7 @@ void book::save()
     }
 
     std::vector<ruling*> filteredRules;
-    for (const auto& rule : qAsConst(m_rules)) {
+    for (const auto& rule : std::as_const(m_rules)) {
         filteredRules.push_back(rule);
     }
 

--- a/como/win/rules/book_settings.cpp
+++ b/como/win/rules/book_settings.cpp
@@ -91,7 +91,7 @@ bool book_settings::usrSave()
     }
 
     // Remove deleted groups from config
-    for (const QString& groupName : qAsConst(m_storedGroups)) {
+    for (const QString& groupName : std::as_const(m_storedGroups)) {
         if (sharedConfig()->hasGroup(groupName) && !mRuleGroupList.contains(groupName)) {
             sharedConfig()->deleteGroup(groupName);
         }
@@ -118,7 +118,7 @@ void book_settings::usrRead()
     mCount = mRuleGroupList.count();
     m_storedGroups = mRuleGroupList;
 
-    for (const QString& groupName : qAsConst(mRuleGroupList)) {
+    for (const QString& groupName : std::as_const(mRuleGroupList)) {
         m_list.push_back(new settings(sharedConfig(), groupName, this));
     }
 }

--- a/como/win/screen_edges.h
+++ b/como/win/screen_edges.h
@@ -1229,11 +1229,11 @@ public:
                 continue;
             }
 
-            if (edge->approach_geometry.contains(event->globalPos())) {
+            if (edge->approach_geometry.contains(event->globalPosition().toPoint())) {
                 if (!edge->is_approaching) {
                     edge->startApproaching();
                 } else {
-                    edge->updateApproaching(event->globalPos());
+                    edge->updateApproaching(event->globalPosition().toPoint());
                 }
             } else {
                 if (edge->is_approaching) {
@@ -1241,8 +1241,8 @@ public:
                 }
             }
 
-            if (edge->geometry.contains(event->globalPos())) {
-                if (edge->check(event->globalPos(),
+            if (edge->geometry.contains(event->globalPosition().toPoint())) {
+                if (edge->check(event->globalPosition().toPoint(),
                                 std::chrono::system_clock::time_point(
                                     std::chrono::milliseconds(event->timestamp())))) {
                     if (edge->client()) {
@@ -1255,7 +1255,7 @@ public:
         if (activatedForClient) {
             for (auto& edge : edges) {
                 if (edge->client()) {
-                    edge->markAsTriggered(event->globalPos(),
+                    edge->markAsTriggered(event->globalPosition().toPoint(),
                                           std::chrono::system_clock::time_point(
                                               std::chrono::milliseconds(event->timestamp())));
                 }

--- a/como/win/screen_edges.h
+++ b/como/win/screen_edges.h
@@ -1727,7 +1727,7 @@ private:
 
         auto const& outputs = space.base.outputs;
         auto const geo = window->geo.frame;
-        auto const fullArea = space_window_area(space, area_option::full, 0, 1);
+        auto const fullArea = space_window_area(space, area_option::full, nullptr, 1);
         base::output* foundOutput = nullptr;
 
         for (auto output : outputs) {

--- a/como/win/tabbox/tabbox.h
+++ b/como/win/tabbox/tabbox.h
@@ -417,7 +417,7 @@ public:
 
         auto contains = [](QKeySequence const& shortcut, int key) -> bool {
             for (int i = 0; i < shortcut.count(); ++i) {
-                if (shortcut[i] == key) {
+                if (shortcut[i].toCombined() == key) {
                     return true;
                 }
             }
@@ -440,10 +440,12 @@ public:
                 | Qt::MetaModifier | Qt::KeypadModifier | Qt::GroupSwitchModifier;
             mods &= keyQt;
             if ((keyQt & ~mods) == Qt::Key_Tab) {
-                if (contains(forward, mods | Qt::Key_Backtab))
+                if (contains(forward, QKeyCombination(mods, Qt::Key_Backtab).toCombined())) {
                     return Forward;
-                if (contains(backward, mods | Qt::Key_Backtab))
+                }
+                if (contains(backward, QKeyCombination(mods, Qt::Key_Backtab).toCombined())) {
                     return Backward;
+                }
             }
 
             // if the shortcuts do not match, try matching again after filtering the shift key from

--- a/como/win/tabbox/tabbox.h
+++ b/como/win/tabbox/tabbox.h
@@ -967,7 +967,7 @@ private:
             borders.clear();
             auto list = cfg_group.readEntry(border_config, QStringList());
 
-            for (auto const& s : qAsConst(list)) {
+            for (auto const& s : std::as_const(list)) {
                 bool ok;
                 auto i = s.toInt(&ok);
                 if (!ok) {

--- a/como/win/tabbox/tabbox.h
+++ b/como/win/tabbox/tabbox.h
@@ -283,7 +283,7 @@ public:
         }
         switch (event->type()) {
         case QEvent::MouseMove:
-            if (!handler->contains_pos(event->globalPos())) {
+            if (!handler->contains_pos(event->globalPosition())) {
                 // filter out all events which are not on the TabBox window.
                 // We don't want windows to react on the mouse events
                 return true;
@@ -291,7 +291,7 @@ public:
             return false;
         case QEvent::MouseButtonPress:
             if ((!is_natively_shown && is_displayed())
-                || !handler->contains_pos(event->globalPos())) {
+                || !handler->contains_pos(event->globalPosition())) {
                 close(); // click outside closes tab
                 return true;
             }

--- a/como/win/tabbox/tabbox_handler.cpp
+++ b/como/win/tabbox/tabbox_handler.cpp
@@ -433,14 +433,14 @@ void tabbox_handler::grabbed_key_event(QKeyEvent* event) const
     QCoreApplication::sendEvent(d->window(), event);
 }
 
-bool tabbox_handler::contains_pos(const QPoint& pos) const
+bool tabbox_handler::contains_pos(QPointF const& pos) const
 {
     if (!d->m_main_item) {
         return false;
     }
     QWindow* w = d->window();
     if (w) {
-        return w->geometry().contains(pos);
+        return w->geometry().contains(pos.toPoint());
     }
     return false;
 }

--- a/como/win/tabbox/tabbox_handler.h
+++ b/como/win/tabbox/tabbox_handler.h
@@ -257,7 +257,7 @@ public:
      * @param pos The position to be tested in global coordinates
      * @return True if the view contains the point, otherwise false.
      */
-    bool contains_pos(const QPoint& pos) const;
+    bool contains_pos(QPointF const& pos) const;
     /**
      * @param client The tabbox_client whose index should be returned
      * @return Returns the ModelIndex of given tabbox_client or an invalid ModelIndex

--- a/como/win/wayland/xdg_activation.h
+++ b/como/win/wayland/xdg_activation.h
@@ -32,7 +32,7 @@ inline constexpr size_t token_strlen{33};
 
 inline bool generate_token(char out[token_strlen])
 {
-    static FILE* urandom = NULL;
+    static FILE* urandom = nullptr;
     uint64_t data[2];
 
     if (!urandom) {

--- a/como/win/x11/event.h
+++ b/como/win/x11/event.h
@@ -383,8 +383,11 @@ void leave_notify_event(Win* win, xcb_leave_notify_event_t* e)
             if (auto deco = win::decoration(win)) {
                 // sending a move instead of a leave. With leave we need to send proper coords, with
                 // move it's handled internally
-                QHoverEvent leaveEvent(
-                    QEvent::HoverMove, QPointF(-1, -1), QPointF(-1, -1), Qt::NoModifier);
+                QHoverEvent leaveEvent(QEvent::HoverMove,
+                                       QPointF(-1, -1),
+                                       QPointF(-1, -1),
+                                       QPointF(-1, -1),
+                                       Qt::NoModifier);
                 QCoreApplication::sendEvent(deco, &leaveEvent);
             }
         }
@@ -613,7 +616,7 @@ bool motion_notify_event(Win* win, xcb_window_t w, int state, int x, int y, int 
 {
     if (w == win->frameId() && win::decoration(win) && !win->control->minimized) {
         // TODO Mouse move event dependent on state
-        QHoverEvent event(QEvent::HoverMove, QPointF(x, y), QPointF(x, y));
+        QHoverEvent event(QEvent::HoverMove, QPointF(x, y), QPointF(x, y), QPointF(x, y));
         QCoreApplication::instance()->sendEvent(win::decoration(win), &event);
     }
     if (w != win->frameId() && w != win->xcb_windows.input && w != win->xcb_windows.grab) {
@@ -626,7 +629,7 @@ bool motion_notify_event(Win* win, xcb_window_t w, int state, int x, int y, int 
             int y = y_root - win->geo.frame.y(); // + padding_top;
 
             if (win::decoration(win)) {
-                QHoverEvent event(QEvent::HoverMove, QPointF(x, y), QPointF(x, y));
+                QHoverEvent event(QEvent::HoverMove, QPointF(x, y), QPointF(x, y), QPointF(x, y));
                 QCoreApplication::instance()->sendEvent(win::decoration(win), &event);
             }
         }

--- a/plugins/effects/cube/cube.cpp
+++ b/plugins/effects/cube/cube.cpp
@@ -124,13 +124,13 @@ bool CubeEffect::supported()
 void CubeEffect::reconfigure(ReconfigureFlags)
 {
     CubeConfig::self()->read();
-    for (auto const& border : qAsConst(borderActivate)) {
+    for (auto const& border : std::as_const(borderActivate)) {
         effects->unreserveElectricBorder(border, this);
     }
-    for (auto const& border : qAsConst(borderActivateCylinder)) {
+    for (auto const& border : std::as_const(borderActivateCylinder)) {
         effects->unreserveElectricBorder(border, this);
     }
-    for (auto const& border : qAsConst(borderActivateSphere)) {
+    for (auto const& border : std::as_const(borderActivateSphere)) {
         effects->unreserveElectricBorder(border, this);
     }
     borderActivate.clear();
@@ -139,21 +139,21 @@ void CubeEffect::reconfigure(ReconfigureFlags)
     QList<int> borderList = QList<int>();
     borderList.append(int(ElectricNone));
     borderList = CubeConfig::borderActivate();
-    for (auto i : qAsConst(borderList)) {
+    for (auto i : std::as_const(borderList)) {
         borderActivate.append(ElectricBorder(i));
         effects->reserveElectricBorder(ElectricBorder(i), this);
     }
     borderList.clear();
     borderList.append(int(ElectricNone));
     borderList = CubeConfig::borderActivateCylinder();
-    for (auto i : qAsConst(borderList)) {
+    for (auto i : std::as_const(borderList)) {
         borderActivateCylinder.append(ElectricBorder(i));
         effects->reserveElectricBorder(ElectricBorder(i), this);
     }
     borderList.clear();
     borderList.append(int(ElectricNone));
     borderList = CubeConfig::borderActivateSphere();
-    for (auto i : qAsConst(borderList)) {
+    for (auto i : std::as_const(borderList)) {
         borderActivateSphere.append(ElectricBorder(i));
         effects->reserveElectricBorder(ElectricBorder(i), this);
     }
@@ -1278,7 +1278,7 @@ void CubeEffect::paintWindow(effect::window_paint_data& data)
             && (data.paint.mask & PAINT_WINDOW_TRANSFORMED)) {
             auto rect = effects->clientArea(FullArea, activeScreen, subspaces.at(prev_desktop));
             WindowQuadList new_quads;
-            for (auto const& quad : qAsConst(data.quads)) {
+            for (auto const& quad : std::as_const(data.quads)) {
                 if (quad.right() > rect.width() - data.window.x()) {
                     new_quads.append(quad);
                 }
@@ -1291,7 +1291,7 @@ void CubeEffect::paintWindow(effect::window_paint_data& data)
             && (data.paint.mask & PAINT_WINDOW_TRANSFORMED)) {
             QRect rect = effects->clientArea(FullArea, activeScreen, subspaces.at(next_desktop));
             WindowQuadList new_quads;
-            for (auto const& quad : qAsConst(data.quads)) {
+            for (auto const& quad : std::as_const(data.quads)) {
                 if (data.window.x() + quad.right() <= rect.x()) {
                     new_quads.append(quad);
                 }
@@ -1333,7 +1333,7 @@ void CubeEffect::paintWindow(effect::window_paint_data& data)
 
         if (data.window.isOnDesktop(painting_desktop) && data.window.x() < rect.x()) {
             WindowQuadList new_quads;
-            for (auto const& quad : qAsConst(data.quads)) {
+            for (auto const& quad : std::as_const(data.quads)) {
                 if (quad.right() > -data.window.x()) {
                     new_quads.append(quad);
                 }
@@ -1343,7 +1343,7 @@ void CubeEffect::paintWindow(effect::window_paint_data& data)
         if (data.window.isOnDesktop(painting_desktop)
             && data.window.x() + data.window.width() > rect.x() + rect.width()) {
             WindowQuadList new_quads;
-            for (auto const& quad : qAsConst(data.quads)) {
+            for (auto const& quad : std::as_const(data.quads)) {
                 if (quad.right() <= rect.width() - data.window.x()) {
                     new_quads.append(quad);
                 }
@@ -1352,7 +1352,7 @@ void CubeEffect::paintWindow(effect::window_paint_data& data)
         }
         if (data.window.y() < rect.y()) {
             WindowQuadList new_quads;
-            for (auto const& quad : qAsConst(data.quads)) {
+            for (auto const& quad : std::as_const(data.quads)) {
                 if (quad.bottom() > -data.window.y()) {
                     new_quads.append(quad);
                 }
@@ -1361,7 +1361,7 @@ void CubeEffect::paintWindow(effect::window_paint_data& data)
         }
         if (data.window.y() + data.window.height() > rect.y() + rect.height()) {
             WindowQuadList new_quads;
-            for (auto const& quad : qAsConst(data.quads)) {
+            for (auto const& quad : std::as_const(data.quads)) {
                 if (quad.bottom() <= rect.height() - data.window.y()) {
                     new_quads.append(quad);
                 }

--- a/plugins/effects/cubeslide/cubeslide.cpp
+++ b/plugins/effects/cubeslide/cubeslide.cpp
@@ -256,7 +256,7 @@ void CubeSlideEffect::paintWindow(effect::window_paint_data& data)
     if (data.window.isOnDesktop(painting_desktop)) {
         if (data.window.x() < rect.x()) {
             WindowQuadList new_quads;
-            for (auto const& quad : qAsConst(data.quads)) {
+            for (auto const& quad : std::as_const(data.quads)) {
                 if (quad.right() > -data.window.x()) {
                     new_quads.append(quad);
                 }
@@ -265,7 +265,7 @@ void CubeSlideEffect::paintWindow(effect::window_paint_data& data)
         }
         if (data.window.x() + data.window.width() > rect.x() + rect.width()) {
             WindowQuadList new_quads;
-            for (auto const& quad : qAsConst(data.quads)) {
+            for (auto const& quad : std::as_const(data.quads)) {
                 if (quad.right() <= rect.width() - data.window.x()) {
                     new_quads.append(quad);
                 }
@@ -274,7 +274,7 @@ void CubeSlideEffect::paintWindow(effect::window_paint_data& data)
         }
         if (data.window.y() < rect.y()) {
             WindowQuadList new_quads;
-            for (auto const& quad : qAsConst(data.quads)) {
+            for (auto const& quad : std::as_const(data.quads)) {
                 if (quad.bottom() > -data.window.y()) {
                     new_quads.append(quad);
                 }
@@ -283,7 +283,7 @@ void CubeSlideEffect::paintWindow(effect::window_paint_data& data)
         }
         if (data.window.y() + data.window.height() > rect.y() + rect.height()) {
             WindowQuadList new_quads;
-            for (auto const& quad : qAsConst(data.quads)) {
+            for (auto const& quad : std::as_const(data.quads)) {
                 if (quad.bottom() <= rect.height() - data.window.y()) {
                     new_quads.append(quad);
                 }
@@ -299,7 +299,7 @@ void CubeSlideEffect::paintWindow(effect::window_paint_data& data)
         if (data.window.x() < rect.x() && (direction == Left || direction == Right)) {
             WindowQuadList new_quads;
             data.paint.geo.translation.setX(rect.width());
-            for (auto const& quad : qAsConst(data.quads)) {
+            for (auto const& quad : std::as_const(data.quads)) {
                 if (quad.right() <= -data.window.x()) {
                     new_quads.append(quad);
                 }
@@ -311,7 +311,7 @@ void CubeSlideEffect::paintWindow(effect::window_paint_data& data)
             && (direction == Left || direction == Right)) {
             WindowQuadList new_quads;
             data.paint.geo.translation.setX(-rect.width());
-            for (auto const& quad : qAsConst(data.quads)) {
+            for (auto const& quad : std::as_const(data.quads)) {
                 if (quad.right() > rect.width() - data.window.x()) {
                     new_quads.append(quad);
                 }
@@ -322,7 +322,7 @@ void CubeSlideEffect::paintWindow(effect::window_paint_data& data)
         if (data.window.y() < rect.y() && (direction == Upwards || direction == Downwards)) {
             WindowQuadList new_quads;
             data.paint.geo.translation.setY(rect.height());
-            for (auto const& quad : qAsConst(data.quads)) {
+            for (auto const& quad : std::as_const(data.quads)) {
                 if (quad.bottom() <= -data.window.y()) {
                     new_quads.append(quad);
                 }
@@ -334,7 +334,7 @@ void CubeSlideEffect::paintWindow(effect::window_paint_data& data)
             && (direction == Upwards || direction == Downwards)) {
             WindowQuadList new_quads;
             data.paint.geo.translation.setY(-rect.height());
-            for (auto const& quad : qAsConst(data.quads)) {
+            for (auto const& quad : std::as_const(data.quads)) {
                 if (quad.bottom() > rect.height() - data.window.y()) {
                     new_quads.append(quad);
                 }
@@ -408,7 +408,7 @@ void CubeSlideEffect::postPaintScreen()
 
         if (slideRotations.empty()) {
             auto const keys = staticWindows.keys();
-            for (EffectWindow* w : qAsConst(keys)) {
+            for (EffectWindow* w : std::as_const(keys)) {
                 w->setData(WindowForceBlurRole, QVariant());
                 w->setData(WindowForceBackgroundContrastRole, QVariant());
             }
@@ -764,7 +764,7 @@ void CubeSlideEffect::slotNumberDesktopsChanged()
     }
 
     auto const keys = staticWindows.keys();
-    for (auto w : qAsConst(keys)) {
+    for (auto w : std::as_const(keys)) {
         w->setData(WindowForceBlurRole, QVariant());
         w->setData(WindowForceBackgroundContrastRole, QVariant());
     }

--- a/plugins/effects/highlightwindow/highlightwindow.cpp
+++ b/plugins/effects/highlightwindow/highlightwindow.cpp
@@ -75,7 +75,7 @@ void HighlightWindowEffect::slotWindowAdded(EffectWindow* w)
             return;
         }
         // This window was demanded to be highlighted before it appeared on the screen.
-        for (const WId& id : qAsConst(m_highlightedIds)) {
+        for (const WId& id : std::as_const(m_highlightedIds)) {
             if (w == effects->findWindow(id)) {
                 const quint64 animationId = startHighlightAnimation(w);
                 complete(animationId);

--- a/plugins/effects/mousemark/mousemark.cpp
+++ b/plugins/effects/mousemark/mousemark.cpp
@@ -123,10 +123,10 @@ void MouseMarkEffect::paintScreen(effect::screen_paint_data& data)
         binder.shader()->setUniform(GLShader::ModelViewProjectionMatrix, effect::get_mvp(data));
         binder.shader()->setUniform(GLShader::ColorUniform::Color, color);
         QVector<QVector2D> verts;
-        for (auto const& mark : qAsConst(marks)) {
+        for (auto const& mark : std::as_const(marks)) {
             verts.clear();
             verts.reserve(mark.size() * 2);
-            for (auto const& p : qAsConst(mark)) {
+            for (auto const& p : std::as_const(mark)) {
                 verts.push_back(QVector2D(p.x(), p.y()));
             }
             vbo->setVertices(verts);
@@ -135,7 +135,7 @@ void MouseMarkEffect::paintScreen(effect::screen_paint_data& data)
         if (!drawing.isEmpty()) {
             verts.clear();
             verts.reserve(drawing.size() * 2);
-            for (auto const& p : qAsConst(drawing)) {
+            for (auto const& p : std::as_const(drawing)) {
                 verts.push_back(QVector2D(p.x(), p.y()));
             }
             vbo->setVertices(verts);
@@ -153,7 +153,7 @@ void MouseMarkEffect::paintScreen(effect::screen_paint_data& data)
         QPen pen(color);
         pen.setWidth(width);
         painter->setPen(pen);
-        for (auto const& mark : qAsConst(marks)) {
+        for (auto const& mark : std::as_const(marks)) {
             drawMark(painter, mark);
         }
         drawMark(painter, drawing);

--- a/plugins/effects/overview/overvieweffect.cpp
+++ b/plugins/effects/overview/overvieweffect.cpp
@@ -213,7 +213,7 @@ void OverviewEffect::reconfigure(ReconfigureFlags)
     setAnimationDuration(animationTime(300));
     setFilterWindows(OverviewConfig::filterWindows());
 
-    for (const ElectricBorder& border : qAsConst(m_borderActivate)) {
+    for (const ElectricBorder& border : std::as_const(m_borderActivate)) {
         effects->unreserveElectricBorder(border, this);
     }
 

--- a/plugins/effects/private/expolayout.cpp
+++ b/plugins/effects/private/expolayout.cpp
@@ -485,7 +485,7 @@ void ExpoLayout::calculateWindowTransformationsNatural()
     QHash<ExpoCell*, QRect> targets;
     QHash<ExpoCell*, int> directions;
 
-    for (ExpoCell* cell : qAsConst(m_cells)) {
+    for (ExpoCell* cell : std::as_const(m_cells)) {
         const QRect cellRect(
             cell->naturalX(), cell->naturalY(), cell->naturalWidth(), cell->naturalHeight());
         targets[cell] = cellRect;
@@ -505,9 +505,9 @@ void ExpoLayout::calculateWindowTransformationsNatural()
     bool overlap;
     do {
         overlap = false;
-        for (ExpoCell* cell : qAsConst(m_cells)) {
+        for (ExpoCell* cell : std::as_const(m_cells)) {
             QRect* target_w = &targets[cell];
-            for (ExpoCell* e : qAsConst(m_cells)) {
+            for (ExpoCell* e : std::as_const(m_cells)) {
                 if (cell == e) {
                     continue;
                 }
@@ -617,7 +617,7 @@ void ExpoLayout::calculateWindowTransformationsNatural()
         bool moved;
         do {
             moved = false;
-            for (ExpoCell* cell : qAsConst(m_cells)) {
+            for (ExpoCell* cell : std::as_const(m_cells)) {
                 QRect oldRect;
                 QRect* target = &targets[cell];
                 // This may cause some slight distortion if the windows are enlarged a large amount
@@ -694,7 +694,7 @@ void ExpoLayout::calculateWindowTransformationsNatural()
         // The expanding code above can actually enlarge windows over 1.0/2.0 scale, we don't like
         // this We can't add this to the loop above as it would cause a never-ending loop so we have
         // to make do with the less-than-optimal space usage with using this method.
-        for (ExpoCell* cell : qAsConst(m_cells)) {
+        for (ExpoCell* cell : std::as_const(m_cells)) {
             QRect* target = &targets[cell];
             qreal scale = target->width() / qreal(cell->naturalWidth());
             if (scale > 2.0
@@ -708,7 +708,7 @@ void ExpoLayout::calculateWindowTransformationsNatural()
         }
     }
 
-    for (ExpoCell* cell : qAsConst(m_cells)) {
+    for (ExpoCell* cell : std::as_const(m_cells)) {
         const QRect rect = centered(cell, targets.value(cell).marginsRemoved(cell->margins()));
 
         cell->setX(rect.x());

--- a/plugins/effects/screenshot/screenshot.cpp
+++ b/plugins/effects/screenshot/screenshot.cpp
@@ -139,7 +139,7 @@ QFuture<QImage> ScreenShotEffect::scheduleScreenShot(const QRect& area, ScreenSh
 
     auto devicePixelRatio = 1.;
     if (flags & ScreenShotNativeResolution) {
-        for (auto const screen : qAsConst(data.screens)) {
+        for (auto const screen : std::as_const(data.screens)) {
             if (screen->devicePixelRatio() > devicePixelRatio) {
                 devicePixelRatio = screen->devicePixelRatio();
             }

--- a/plugins/effects/slide/slide.cpp
+++ b/plugins/effects/slide/slide.cpp
@@ -210,7 +210,7 @@ void SlideEffect::paintWindow(effect::window_paint_data& data)
 
     const auto screens = effects->screens();
 
-    for (auto desktop : qAsConst(m_paintCtx.visibleDesktops)) {
+    for (auto desktop : std::as_const(m_paintCtx.visibleDesktops)) {
         if (!data.window.isOnDesktop(desktop)) {
             continue;
         }
@@ -333,7 +333,7 @@ void SlideEffect::finishedSwitching()
         w->setData(WindowForceBlurRole, QVariant());
     }
 
-    for (EffectWindow* w : qAsConst(m_elevatedWindows)) {
+    for (EffectWindow* w : std::as_const(m_elevatedWindows)) {
         effects->setElevatedWindow(w, false);
     }
 

--- a/plugins/effects/slideback/slideback.cpp
+++ b/plugins/effects/slideback/slideback.cpp
@@ -62,7 +62,7 @@ void SlideBackEffect::windowRaised(EffectWindow* w)
 {
     // Determine all windows on top of the activated one
     bool currentFound = false;
-    for (auto const& tmp : qAsConst(oldStackingOrder)) {
+    for (auto const& tmp : std::as_const(oldStackingOrder)) {
         if (!currentFound) {
             if (tmp == w) {
                 currentFound = true;
@@ -82,7 +82,7 @@ void SlideBackEffect::windowRaised(EffectWindow* w)
                 } else {
                     // Does it intersect with a moved (elevated) window and do we have to elevate it
                     // too?
-                    for (auto const& elevatedWindow : qAsConst(elevatedList)) {
+                    for (auto const& elevatedWindow : std::as_const(elevatedList)) {
                         if (tmp->frameGeometry().intersects(elevatedWindow->frameGeometry())) {
                             effects->setElevatedWindow(tmp, true);
                             elevatedList.append(tmp);
@@ -100,7 +100,7 @@ void SlideBackEffect::windowRaised(EffectWindow* w)
     // If a window is minimized it could happen that the panels stay elevated without any windows
     // sliding. clear all elevation settings
     if (!motionManager.managingWindows()) {
-        for (auto const& tmp : qAsConst(elevatedList)) {
+        for (auto const& tmp : std::as_const(elevatedList)) {
             effects->setElevatedWindow(tmp, false);
         }
     }
@@ -182,7 +182,7 @@ void SlideBackEffect::paintWindow(effect::window_paint_data& data)
         motionManager.apply(data);
     }
 
-    for (auto const& r : qAsConst(clippedRegions)) {
+    for (auto const& r : std::as_const(clippedRegions)) {
         data.paint.region = data.paint.region.intersected(r);
     }
 
@@ -205,7 +205,7 @@ void SlideBackEffect::postPaintWindow(EffectWindow* w)
                 // more except panels
                 if (coveringWindows.contains(w)) {
                     QList<EffectWindow*> tmpList;
-                    for (auto const& tmp : qAsConst(elevatedList)) {
+                    for (auto const& tmp : std::as_const(elevatedList)) {
                         QRect elevatedGeometry = tmp->frameGeometry();
                         if (motionManager.isManaging(tmp)) {
                             elevatedGeometry
@@ -224,7 +224,7 @@ void SlideBackEffect::postPaintWindow(EffectWindow* w)
                         } else {
                             if (!tmp->isDock()) {
                                 bool keepElevated = false;
-                                for (auto const& elevatedWindow : qAsConst(tmpList)) {
+                                for (auto const& elevatedWindow : std::as_const(tmpList)) {
                                     if (tmp->frameGeometry().intersects(
                                             elevatedWindow->frameGeometry())) {
                                         keepElevated = true;
@@ -261,7 +261,7 @@ void SlideBackEffect::postPaintWindow(EffectWindow* w)
                 coveringWindows.removeAll(w);
                 if (coveringWindows.isEmpty()) {
                     // Restore correct stacking order
-                    for (auto const& tmp : qAsConst(elevatedList)) {
+                    for (auto const& tmp : std::as_const(elevatedList)) {
                         effects->setElevatedWindow(tmp, false);
                     }
                     elevatedList.clear();
@@ -340,7 +340,7 @@ QList<EffectWindow*> SlideBackEffect::usableWindows(QList<EffectWindow*> const& 
     auto isWindowVisible = [](const EffectWindow* window) {
         return window && effects->virtualScreenGeometry().intersects(window->frameGeometry());
     };
-    for (auto const& tmp : qAsConst(allWindows)) {
+    for (auto const& tmp : std::as_const(allWindows)) {
         if (isWindowUsable(tmp) && isWindowVisible(tmp)) {
             retList.append(tmp);
         }
@@ -353,7 +353,7 @@ QRect SlideBackEffect::getModalGroupGeometry(EffectWindow* w)
     QRect modalGroupGeometry = w->frameGeometry();
     if (w->isModal()) {
         auto const& main_windows = w->mainWindows();
-        for (auto const& modalWindow : qAsConst(main_windows)) {
+        for (auto const& modalWindow : std::as_const(main_windows)) {
             modalGroupGeometry = modalGroupGeometry.united(getModalGroupGeometry(modalWindow));
         }
     }

--- a/plugins/effects/snaphelper/snaphelper.cpp
+++ b/plugins/effects/snaphelper/snaphelper.cpp
@@ -30,7 +30,7 @@ static QRegion computeDirtyRegion(const QRect& windowRect)
 
     const QList<EffectScreen*> screens = effects->screens();
     for (EffectScreen* screen : screens) {
-        const QRect screenRect = effects->clientArea(ScreenArea, screen, 0);
+        auto const screenRect = effects->clientArea(ScreenArea, screen, nullptr);
 
         QRect screenWindowRect = windowRect;
         screenWindowRect.moveCenter(screenRect.center());
@@ -113,7 +113,7 @@ void SnapHelperEffect::paintScreen(effect::screen_paint_data& data)
         QVector<QVector2D> verts;
         verts.reserve(screens.size() * 24);
         for (EffectScreen* screen : screens) {
-            const QRect rect = effects->clientArea(ScreenArea, screen, 0);
+            auto const rect = effects->clientArea(ScreenArea, screen, nullptr);
             const int midX = rect.x() + rect.width() / 2;
             const int midY = rect.y() + rect.height() / 2;
             const int halfWidth = m_geometry.width() / 2;
@@ -160,7 +160,7 @@ void SnapHelperEffect::paintScreen(effect::screen_paint_data& data)
         painter->setBrush(Qt::NoBrush);
 
         for (EffectScreen* screen : screens) {
-            const QRect rect = effects->clientArea(ScreenArea, screen, 0);
+            auto const rect = effects->clientArea(ScreenArea, screen, nullptr);
             // Center lines.
             painter->drawLine(
                 rect.center().x(), rect.y(), rect.center().x(), rect.y() + rect.height());

--- a/plugins/effects/thumbnailaside/thumbnailaside.cpp
+++ b/plugins/effects/thumbnailaside/thumbnailaside.cpp
@@ -81,7 +81,7 @@ void ThumbnailAsideEffect::paintScreen(effect::screen_paint_data& data)
     painted = QRegion();
     effects->paintScreen(data);
 
-    for (auto const& d : qAsConst(windows)) {
+    for (auto const& d : std::as_const(windows)) {
         if (painted.intersects(d.rect)) {
             effect::window_paint_data win_data{
                 *d.window,
@@ -105,7 +105,7 @@ void ThumbnailAsideEffect::paintWindow(effect::window_paint_data& data)
 
 void ThumbnailAsideEffect::slotWindowDamaged(EffectWindow* w, QRegion const&)
 {
-    for (auto const& d : qAsConst(windows)) {
+    for (auto const& d : std::as_const(windows)) {
         if (d.window == w)
             effects->addRepaint(d.rect);
     }
@@ -113,7 +113,7 @@ void ThumbnailAsideEffect::slotWindowDamaged(EffectWindow* w, QRegion const&)
 
 void ThumbnailAsideEffect::slotWindowFrameGeometryChanged(EffectWindow* w, const QRect& old)
 {
-    for (auto const& d : qAsConst(windows)) {
+    for (auto const& d : std::as_const(windows)) {
         if (d.window == w) {
             if (w->size() == old.size())
                 effects->addRepaint(d.rect);
@@ -181,7 +181,7 @@ void ThumbnailAsideEffect::arrange()
     int height = 0;
     QVector<int> pos(windows.size());
     int mwidth = 0;
-    for (auto const& d : qAsConst(windows)) {
+    for (auto const& d : std::as_const(windows)) {
         height += d.window->height();
         mwidth = qMax(mwidth, d.window->width());
         pos[d.index] = d.window->height();
@@ -212,7 +212,7 @@ void ThumbnailAsideEffect::arrange()
 
 void ThumbnailAsideEffect::repaintAll()
 {
-    for (auto const& d : qAsConst(windows)) {
+    for (auto const& d : std::as_const(windows)) {
         effects->addRepaint(d.rect);
     }
 }

--- a/plugins/effects/windowview/windowvieweffect.cpp
+++ b/plugins/effects/windowview/windowvieweffect.cpp
@@ -166,10 +166,10 @@ void WindowViewEffect::reconfigure(ReconfigureFlags)
     setAnimationDuration(animationTime(300));
     setLayout(WindowViewConfig::layoutMode());
 
-    for (ElectricBorder border : qAsConst(m_borderActivate)) {
+    for (ElectricBorder border : std::as_const(m_borderActivate)) {
         effects->unreserveElectricBorder(border, this);
     }
-    for (ElectricBorder border : qAsConst(m_borderActivateAll)) {
+    for (ElectricBorder border : std::as_const(m_borderActivateAll)) {
         effects->unreserveElectricBorder(border, this);
     }
 

--- a/plugins/idletime/poller.cpp
+++ b/plugins/idletime/poller.cpp
@@ -24,7 +24,7 @@ KWinIdleTimePoller::~KWinIdleTimePoller()
 void KWinIdleTimePoller::cleanup()
 {
     if (auto idle_interface = como::input::singleton_interface::idle_qobject) {
-        for (auto& listener : qAsConst(m_timeouts)) {
+        for (auto& listener : std::as_const(m_timeouts)) {
             idle_interface->unregister_listener(*listener);
         }
         if (m_catchResumeTimeout) {

--- a/plugins/kdecorations/aurorae/src/aurorae.cpp
+++ b/plugins/kdecorations/aurorae/src/aurorae.cpp
@@ -715,7 +715,7 @@ void ThemeProvider::findAllSvgThemes()
             themeDirectories << dir + themeDir;
         }
     }
-    for (const QString& dir : qAsConst(themeDirectories)) {
+    for (const QString& dir : std::as_const(themeDirectories)) {
         auto const entry_list
             = QDir(dir).entryList(QStringList() << QStringLiteral("metadata.desktop"));
         for (const QString& file : entry_list) {

--- a/plugins/kdecorations/aurorae/src/aurorae.cpp
+++ b/plugins/kdecorations/aurorae/src/aurorae.cpp
@@ -637,7 +637,7 @@ void Decoration::updateBlur()
         mask = QRect(0, 0, m_item->width(), m_item->height());
     } else {
         const QVariant maskProperty = m_item->property("decorationMask");
-        if (static_cast<QMetaType::Type>(maskProperty.type()) == QMetaType::QRegion) {
+        if (maskProperty.typeId() == QMetaType::QRegion) {
             mask = maskProperty.value<QRegion>();
 
             if (!mask.isNull()) {

--- a/plugins/kdecorations/aurorae/src/aurorae.cpp
+++ b/plugins/kdecorations/aurorae/src/aurorae.cpp
@@ -544,8 +544,12 @@ void Decoration::hoverMoveEvent(QHoverEvent* event)
     if (m_view) {
         // turn a hover event into a mouse because we don't follow hovers as we don't think we have
         // focus
-        QMouseEvent cloneEvent(
-            QEvent::MouseMove, event->position(), Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+        QMouseEvent cloneEvent(QEvent::MouseMove,
+                               event->position(),
+                               event->position(),
+                               Qt::NoButton,
+                               Qt::NoButton,
+                               Qt::NoModifier);
         event->setAccepted(false);
         m_view->forwardMouseEvent(&cloneEvent);
         event->setAccepted(cloneEvent.isAccepted());

--- a/plugins/kdecorations/aurorae/src/aurorae.cpp
+++ b/plugins/kdecorations/aurorae/src/aurorae.cpp
@@ -545,7 +545,7 @@ void Decoration::hoverMoveEvent(QHoverEvent* event)
         // turn a hover event into a mouse because we don't follow hovers as we don't think we have
         // focus
         QMouseEvent cloneEvent(
-            QEvent::MouseMove, event->posF(), Qt::NoButton, Qt::NoButton, Qt::NoModifier);
+            QEvent::MouseMove, event->position(), Qt::NoButton, Qt::NoButton, Qt::NoModifier);
         event->setAccepted(false);
         m_view->forwardMouseEvent(&cloneEvent);
         event->setAccepted(cloneEvent.isAccepted());

--- a/plugins/qpa/eglhelpers.cpp
+++ b/plugins/qpa/eglhelpers.cpp
@@ -77,7 +77,7 @@ configFromFormat(EGLDisplay display, const QSurfaceFormat& surfaceFormat, EGLint
         return EGL_NO_CONFIG_KHR;
     }
 
-    for (const EGLConfig& config : qAsConst(configs)) {
+    for (const EGLConfig& config : std::as_const(configs)) {
         EGLint redConfig, greenConfig, blueConfig, alphaConfig;
         eglGetConfigAttrib(display, config, EGL_RED_SIZE, &redConfig);
         eglGetConfigAttrib(display, config, EGL_GREEN_SIZE, &greenConfig);

--- a/plugins/qpa/integration.cpp
+++ b/plugins/qpa/integration.cpp
@@ -46,7 +46,7 @@ Integration::Integration()
 
 Integration::~Integration()
 {
-    for (QPlatformScreen* platformScreen : qAsConst(m_screens)) {
+    for (QPlatformScreen* platformScreen : std::as_const(m_screens)) {
         QWindowSystemInterface::handleScreenRemoved(platformScreen);
     }
 }

--- a/tests/plasma/main_wayland.cpp
+++ b/tests/plasma/main_wayland.cpp
@@ -303,7 +303,7 @@ int main(int argc, char* argv[])
 
     // start the applications passed to us as command line arguments
     if (auto apps = parser.positionalArguments(); !apps.isEmpty()) {
-        for (auto const& app_name : qAsConst(apps)) {
+        for (auto const& app_name : std::as_const(apps)) {
             auto arguments = KShell::splitArgs(app_name);
             if (arguments.isEmpty()) {
                 qWarning("Failed to launch application: %s is an invalid command",


### PR DESCRIPTION
We add multiple CMake presets which we use in our CI and can be used by consumers.

Additionally we now compile with a lot more compiler warnings enabled and warnings as errors. On our CI we do this for clang *and* gcc now.