### PR TITLE
Add API to close Wayland windows on shutdown

### DIFF
--- a/como/win/CMakeLists.txt
+++ b/como/win/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(win
     FILE_SET HEADERS
     FILES
       dbus/appmenu.h
+      dbus/session_manager.h
       dbus/virtual_desktop_manager.h
       dbus/virtual_desktop_types.h
       deco/bridge.h
@@ -129,6 +130,7 @@ target_sources(win
   PRIVATE
     cursor_shape.cpp
     dbus/appmenu.cpp
+    dbus/session_manager.cpp
     dbus/virtual_desktop_manager.cpp
     dbus/virtual_desktop_types.cpp
     deco/palette.cpp
@@ -183,6 +185,11 @@ qt6_add_dbus_interface(win_dbus_src dbus/org.kde.kappmenu.xml appmenu_interface)
 qt6_add_dbus_interface(win_dbus_src
   ${KSCREENLOCKER_DBUS_INTERFACES_DIR}/kf6_org.freedesktop.ScreenSaver.xml
   screenlocker_interface
+)
+qt6_add_dbus_adaptor(win_dbus_src
+  dbus/org.kde.KWin.Session.xml
+  dbus/session_manager.h
+  como::win::dbus::session_manager
 )
 
 target_sources(win PRIVATE ${win_dbus_src})
@@ -294,14 +301,6 @@ target_sources(win-x11
     x11/net/root_info.cpp
     x11/net/win_info.cpp
 )
-
-qt6_add_dbus_adaptor(win_x11_dbus_src
-  dbus/org.kde.KWin.Session.xml
-  x11/session_manager.h
-  como::win::x11::session_manager
-)
-
-target_sources(win-x11 PRIVATE ${win_x11_dbus_src})
 
 add_library(win-x11-backend SHARED)
 

--- a/como/win/CMakeLists.txt
+++ b/como/win/CMakeLists.txt
@@ -341,6 +341,7 @@ target_sources(win-wl
       wayland/plasma_window.h
       wayland/popup_placement.h
       wayland/scene.h
+      wayland/session_manager.h
       wayland/setup.h
       wayland/space.h
       wayland/space_areas.h

--- a/como/win/dbus/org.kde.KWin.Session.xml
+++ b/como/win/dbus/org.kde.KWin.Session.xml
@@ -22,6 +22,8 @@
       <!-- Shutdown kwin at the end of the session -->
       <method name="quit">
       </method>
+      <method name="closeWaylandWindows">
+          <arg type="b" direction="out" />
+      </method>
    </interface>
 </node>
-

--- a/como/win/dbus/session_manager.cpp
+++ b/como/win/dbus/session_manager.cpp
@@ -1,0 +1,20 @@
+/*
+    SPDX-FileCopyrightText: 2024 Roman Gilg <subdiff@gmail.com>
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+#include "session_manager.h"
+
+// Include first to not clash with later X definitions in other includes.
+#include "sessionadaptor.h"
+
+namespace como::win::dbus
+{
+
+session_manager::session_manager()
+{
+    new SessionAdaptor(this);
+    QDBusConnection::sessionBus().registerObject(QStringLiteral("/Session"), this);
+}
+
+}

--- a/como/win/dbus/session_manager.h
+++ b/como/win/dbus/session_manager.h
@@ -32,6 +32,10 @@ public Q_SLOTS:
     virtual void finishSaveSession(QString const& /*name*/)
     {
     }
+    virtual bool closeWaylandWindows()
+    {
+        return true;
+    }
     virtual void quit()
     {
     }

--- a/como/win/dbus/session_manager.h
+++ b/como/win/dbus/session_manager.h
@@ -1,0 +1,46 @@
+/*
+    SPDX-FileCopyrightText: 2024 Roman Gilg <subdiff@gmail.com>
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+#pragma once
+
+#include <como/win/types.h>
+#include <como_export.h>
+
+#include <QObject>
+
+namespace como::win::dbus
+{
+
+class COMO_EXPORT session_manager : public QObject
+{
+    Q_OBJECT
+public:
+    session_manager();
+
+public Q_SLOTS:
+    virtual void setState(uint /*state*/)
+    {
+    }
+    virtual void loadSession(QString const& /*name*/)
+    {
+    }
+    virtual void aboutToSaveSession(QString const& /*name*/)
+    {
+    }
+    virtual void finishSaveSession(QString const& /*name*/)
+    {
+    }
+    virtual void quit()
+    {
+    }
+
+Q_SIGNALS:
+    void stateChanged(session_state prev, session_state next);
+    void loadSessionRequested(QString const& name);
+    void prepareSessionSaveRequested(QString const& name);
+    void finishSessionSaveRequested(QString const& name);
+};
+
+}

--- a/como/win/wayland/session_manager.h
+++ b/como/win/wayland/session_manager.h
@@ -1,0 +1,21 @@
+/*
+    SPDX-FileCopyrightText: 2024 Roman Gilg <subdiff@gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+#pragma once
+
+#include <como/win/dbus/session_manager.h>
+
+namespace como::win::wayland
+{
+
+class session_manager : public dbus::session_manager
+{
+public:
+    bool closeWaylandWindows() override
+    {
+        return true;
+    }
+};
+
+}

--- a/como/win/wayland/space.h
+++ b/como/win/wayland/space.h
@@ -7,7 +7,6 @@
 
 #include "subsurface.h"
 #include "surface.h"
-#include <como/win/wayland/space_setup.h>
 
 #include <como/debug/console/wayland/wayland_console.h>
 #include <como/win/input.h>
@@ -17,7 +16,9 @@
 #include <como/win/stacking_order.h>
 #include <como/win/stacking_state.h>
 #include <como/win/wayland/internal_window.h>
+#include <como/win/wayland/space_setup.h>
 #include <como/win/wayland/subspace_manager.h>
+#include <win/wayland/session_manager.h>
 
 #include <memory>
 
@@ -46,6 +47,7 @@ public:
     {
         space_setup_init(*this, render, input);
         init_space(*this);
+        session_manager = std::make_unique<wayland::session_manager>();
     }
 
     virtual ~space()
@@ -130,6 +132,7 @@ public:
     std::vector<win::strut_rects> oldrestrictedmovearea;
 
     std::unique_ptr<wayland::subspace_manager> subspace_manager;
+    std::unique_ptr<wayland::session_manager> session_manager;
 
     QTimer* m_quickTileCombineTimer{nullptr};
     win::quicktiles m_lastTilingMode{win::quicktiles::none};

--- a/como/win/x11/session_manager.cpp
+++ b/como/win/x11/session_manager.cpp
@@ -7,9 +7,6 @@
 */
 #include "session_manager.h"
 
-// Include first to not clash with later X definitions in other includes.
-#include "sessionadaptor.h"
-
 #include <como/win/stacking_order.h>
 #include <como/win/x11/geo.h>
 #include <como/win/x11/window.h>
@@ -23,15 +20,7 @@
 namespace como::win::x11
 {
 
-session_manager::session_manager()
-{
-    new SessionAdaptor(this);
-    QDBusConnection::sessionBus().registerObject(QStringLiteral("/Session"), this);
-}
-
-session_manager::~session_manager()
-{
-}
+session_manager::~session_manager() = default;
 
 session_state session_manager::state() const
 {

--- a/como/win/x11/session_manager.h
+++ b/como/win/x11/session_manager.h
@@ -7,39 +7,28 @@
 */
 #pragma once
 
-#include "types.h"
+#include <como/win/dbus/session_manager.h>
+#include <como/win/types.h>
+#include <como_export.h>
 
-#include "como_export.h"
-
-#include <QObject>
 #include <QRect>
 
 namespace como::win::x11
 {
 
-class COMO_EXPORT session_manager : public QObject
+class COMO_EXPORT session_manager : public dbus::session_manager
 {
-    Q_OBJECT
 public:
-    session_manager();
     ~session_manager() override;
 
     session_state state() const;
 
-Q_SIGNALS:
-    void stateChanged(session_state prev, session_state next);
-
-    void loadSessionRequested(const QString& name);
-    void prepareSessionSaveRequested(const QString& name);
-    void finishSessionSaveRequested(const QString& name);
-
-public Q_SLOTS:
-    // DBus API
-    void setState(uint state);
-    void loadSession(const QString& name);
-    void aboutToSaveSession(const QString& name);
-    void finishSaveSession(const QString& name);
-    void quit();
+public:
+    void setState(uint state) override;
+    void loadSession(const QString& name) override;
+    void aboutToSaveSession(const QString& name) override;
+    void finishSaveSession(const QString& name) override;
+    void quit() override;
 
 private:
     void setState(session_state state);


### PR DESCRIPTION
This allows Plasma to gracefully close windows on shutdown. For now this is only a stub in order to provide compatibility. We require logic similar to [this](https://invent.kde.org/plasma/kwin/-/commit/4cdf27e74c) in order to wait on windows closing and react to user input. But this includes many KDE dependencies into our windowing code what we first might want to isolate some more.