### PR TITLE
Manage outputs better in QPA plugin

### DIFF
--- a/plugins/qpa/integration.cpp
+++ b/plugins/qpa/integration.cpp
@@ -83,14 +83,7 @@ void Integration::initialize()
     connect(base::singleton_interface::app_singleton,
             &base::app_singleton::platform_created,
             this,
-            [this] {
-                assert(base::singleton_interface::platform);
-                QObject::connect(base::singleton_interface::platform,
-                                 &base::platform_qobject::topology_changed,
-                                 this,
-                                 &Integration::initScreens);
-                initScreens();
-            });
+            &Integration::handle_platform_created);
 
     QPlatformIntegration::initialize();
     auto dummyScreen = new Screen(nullptr, this);
@@ -152,6 +145,16 @@ QPlatformAccessibility* Integration::accessibility() const
         m_accessibility.reset(new QSpiAccessibleBridge());
     }
     return m_accessibility.get();
+}
+
+void Integration::handle_platform_created()
+{
+    assert(base::singleton_interface::platform);
+    QObject::connect(base::singleton_interface::platform,
+                     &base::platform_qobject::topology_changed,
+                     this,
+                     &Integration::initScreens);
+    initScreens();
 }
 
 void Integration::initScreens()

--- a/plugins/qpa/integration.h
+++ b/plugins/qpa/integration.h
@@ -9,15 +9,22 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <epoxy/egl.h>
 
+#include <QHash>
 #include <QObject>
 #include <QtGui/private/qgenericunixservices_p.h>
 #include <qpa/qplatformintegration.h>
 
 namespace como
 {
+
+namespace base
+{
+class output;
+}
 namespace QPA
 {
 
+class placeholder_screen;
 class Screen;
 
 class Integration : public QObject, public QPlatformIntegration
@@ -42,17 +49,18 @@ public:
     QPlatformServices* services() const override;
     void initialize() override;
 
-    QVector<Screen*> screens() const;
+    QHash<como::base::output*, Screen*> screens() const;
 
 private:
     void handle_platform_created();
-    void initScreens();
+    void handle_output_added(como::base::output*);
+    void handle_output_removed(como::base::output*);
 
     std::unique_ptr<QPlatformFontDatabase> m_fontDb;
     mutable std::unique_ptr<QPlatformAccessibility> m_accessibility;
     QScopedPointer<QPlatformNativeInterface> m_nativeInterface;
-    Screen* m_dummyScreen = nullptr;
-    QVector<Screen*> m_screens;
+    placeholder_screen* m_dummyScreen{nullptr};
+    QHash<como::base::output*, Screen*> m_screens;
     QScopedPointer<QGenericUnixServices> m_services;
 };
 

--- a/plugins/qpa/integration.h
+++ b/plugins/qpa/integration.h
@@ -45,6 +45,7 @@ public:
     QVector<Screen*> screens() const;
 
 private:
+    void handle_platform_created();
     void initScreens();
 
     std::unique_ptr<QPlatformFontDatabase> m_fontDb;

--- a/plugins/qpa/screen.h
+++ b/plugins/qpa/screen.h
@@ -20,7 +20,7 @@ namespace QPA
 class Integration;
 class PlatformCursor;
 
-class Screen : public QPlatformScreen
+class Screen : public QPlatformScreen, public QObject
 {
 public:
     explicit Screen(base::output* output, Integration* integration);
@@ -40,6 +40,12 @@ private:
     base::output* output;
     QScopedPointer<PlatformCursor> m_cursor;
     Integration* m_integration;
+};
+
+class placeholder_screen : public QPlatformPlaceholderScreen
+{
+public:
+    QDpi logicalDpi() const override;
 };
 
 }


### PR DESCRIPTION
Do not recreate all screens on output changes, instead listen directly for
`output_added` and `output_removed` signals.