### PR TITLE
Improve CI testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: string
         default: ''
+      cmake-args:
+        description: Specify additional CMake arguments
+        required: false
+        type: string
+        default: ''
 jobs:
   build:
     name: Build
@@ -38,7 +43,7 @@ jobs:
         if: ${{ inputs.cmake-preset != '' }}
         run: echo "cmake-preset=--preset ${{ inputs.cmake-preset }}" >> $GITHUB_ENV
       - name: Configure
-        run: cmake ${{ env.cmake-preset }} -S . -B build
+        run: cmake ${{ env.cmake-preset }} ${{ inputs.cmake-args }} -S . -B build
       - name: Build
         run: cmake --build build
       - name: Tar artifact (keep permissions)

--- a/.github/workflows/change.yml
+++ b/.github/workflows/change.yml
@@ -20,22 +20,23 @@ jobs:
   clang-format:
     uses: ./.github/workflows/clang-format.yml
 
-  coverage-build:
+  clang-build:
     uses: ./.github/workflows/build.yml
     with:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
-      artifact-name: coverage-build
-      cmake-preset: gcc-cov
+      artifact-name: clang-build
+      cmake-preset: clang
 
   builds:
     strategy:
       matrix:
-        preset: [clang, gcc, release]
+        preset: [gcc-cov, release]
     uses: ./.github/workflows/build.yml
     with:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
-      artifact-name: '${{ matrix.preset }}-build'
+      artifact-name: ${{ matrix.preset }}-build
       cmake-preset: ${{ matrix.preset }}
+      cmake-args: -DBUILD_TESTING=ON
 
   install:
     uses: ./.github/workflows/install.yml
@@ -44,13 +45,18 @@ jobs:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
       artifact-name: release-build
 
-  test:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        preset: [gcc-cov, release]
     uses: ./.github/workflows/test.yml
-    needs: coverage-build
+    needs: builds
     secrets: inherit
     with:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
-      artifact-name: coverage-build
+      artifact-prefix: ${{ matrix.preset }}
+      coverage: ${{ matrix.preset == 'gcc-cov' }}
       # Following tests are currently disabled on CI:
       # * lockscreen, modifier-only-shortcut: flaky on CI because the lockscreen greeter process likes to
       #   freeze off. Also see: https://bugreports.qt.io/browse/QTBUG-82911
@@ -64,7 +70,7 @@ jobs:
 
   clang-tidy:
     uses: ./.github/workflows/clang-tidy.yml
-    needs: builds
+    needs: clang-build
     with:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
       artifact-name: clang-build
@@ -74,5 +80,5 @@ jobs:
     needs: builds
     with:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master
-      artifact-name: clang-build
+      artifact-name: release-build
       package-name: como

--- a/.github/workflows/change.yml
+++ b/.github/workflows/change.yml
@@ -30,7 +30,7 @@ jobs:
   builds:
     strategy:
       matrix:
-        preset: [clang, release]
+        preset: [clang, gcc, release]
     uses: ./.github/workflows/build.yml
     with:
       image: registry.gitlab.com/kwinft/ci-images/archlinux/kwinft-base-master

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -12,6 +12,11 @@ on:
         description: Artifact name of build dir
         required: true
         type: string
+      threads:
+        description: Parallel execution count
+        required: false
+        type: number
+        default: 0
 
 jobs:
   clang-tidy:
@@ -33,8 +38,5 @@ jobs:
       - name: Untar artifact
         run: tar -xzf build-dir.tar
       - name: Run Clang-Tidy
-        # TODO(romangg): For now we skip the actual clang-tidy operation on CI because
-        # the process consumes too much resources and the runner terminates.
-        if: false
-        run: tooling/analysis/clang-tidy.py -p build
+        run: tooling/analysis/clang-tidy.py -p build -j ${{ inputs.threads }}
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ on:
         description: Image to run tests on
         required: true
         type: string
-      artifact-name:
-        description: Artifact name of build dir
+      artifact-prefix:
+        description: Artifact prefix of build dir
         required: true
         type: string
       ctest-args:
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: ''
+      coverage:
+        description: Option to create coverage
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   test:
@@ -34,7 +39,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.artifact-name }}
+          name: ${{ inputs.artifact-prefix }}-build
       - name: Untar artifact
         run: tar -xzf build-dir.tar
       - name: List all tests
@@ -55,10 +60,11 @@ jobs:
             --output-on-failure --no-compress-output ${{ inputs.ctest-args }}"
         shell: bash
       - name: Generate a code coverage report
+        if: ${{ inputs.coverage }}
         uses: ./.github/actions/coverage
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v4
-        if: github.repository == 'winft/como' || github.event_name == 'pull_request'
+        if: ${{ inputs.coverage && (github.repository == 'winft/como' || github.event_name == 'pull_request') }}
         with:
           file: coverage.xml
           fail_ci_if_error: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,7 @@ ecm_find_qmlmodule(org.kde.kquickcontrolsaddons 2.0)
 ecm_find_qmlmodule(org.kde.plasma.core 2.0)
 ecm_find_qmlmodule(org.kde.plasma.components 2.0)
 
+option(BUILD_EXAMPLES "Enable building examples." ON)
 option(COMO_BUILD_DECORATIONS "Enable building of decorations." ON)
 option(COMO_BUILD_KCMS "Enable building of configuration modules." ON)
 option(COMO_BUILD_TABBOX "Enable building of Tabbox functionality" ON)
@@ -342,7 +343,9 @@ if (BUILD_TESTING)
     add_subdirectory(tests)
 endif()
 
-add_subdirectory(examples)
+if (BUILD_EXAMPLES)
+  add_subdirectory(examples)
+endif()
 
 if (KF6DocTools_FOUND)
     add_subdirectory(docs)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -72,20 +72,6 @@
       }
     },
     {
-      "name": "clang-cov",
-      "inherits": "clang",
-      "displayName": "Clang Tests Coverage",
-      "description": "Clang Build with tests and coverage reporting enabled",
-      "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "$env{DEBUG_CXX_FLAGS_CLANG} --coverage",
-        "CMAKE_EXE_LINKER_FLAGS": "--coverage",
-        "BUILD_EXAMPLES": {
-          "type": "BOOL",
-          "value": "OFF"
-        }
-      }
-    },
-    {
       "name": "gcc-cov",
       "inherits": "gcc",
       "displayName": "GCC Tests Coverage",
@@ -95,11 +81,7 @@
         "CMAKE_CXX_FLAGS": "$env{DEBUG_CXX_FLAGS_GCC} --coverage -fprofile-abs-path",
         "CMAKE_SHARED_LINKER_FLAGS": "$env{DEBUG_SHARED_LINKER_FLAGS} $env{NOUNDEF_LINKER_FLAGS} --coverage -fprofile-abs-path",
         "CMAKE_MODULE_LINKER_FLAGS": "$env{DEBUG_MODULE_LINKER_FLAGS} $env{NOUNDEF_LINKER_FLAGS} --coverage -fprofile-abs-path",
-        "CMAKE_EXE_LINKER_FLAGS": "--coverage -fprofile-abs-path",
-        "BUILD_EXAMPLES": {
-          "type": "BOOL",
-          "value": "OFF"
-        }
+        "CMAKE_EXE_LINKER_FLAGS": "--coverage -fprofile-abs-path"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -78,7 +78,11 @@
       "description": "Clang Build with tests and coverage reporting enabled",
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "$env{DEBUG_CXX_FLAGS_CLANG} --coverage",
-        "CMAKE_EXE_LINKER_FLAGS": "--coverage"
+        "CMAKE_EXE_LINKER_FLAGS": "--coverage",
+        "BUILD_EXAMPLES": {
+          "type": "BOOL",
+          "value": "OFF"
+        }
       }
     },
     {
@@ -91,7 +95,11 @@
         "CMAKE_CXX_FLAGS": "$env{DEBUG_CXX_FLAGS_GCC} --coverage -fprofile-abs-path",
         "CMAKE_SHARED_LINKER_FLAGS": "$env{DEBUG_SHARED_LINKER_FLAGS} $env{NOUNDEF_LINKER_FLAGS} --coverage -fprofile-abs-path",
         "CMAKE_MODULE_LINKER_FLAGS": "$env{DEBUG_MODULE_LINKER_FLAGS} $env{NOUNDEF_LINKER_FLAGS} --coverage -fprofile-abs-path",
-        "CMAKE_EXE_LINKER_FLAGS": "--coverage -fprofile-abs-path"
+        "CMAKE_EXE_LINKER_FLAGS": "--coverage -fprofile-abs-path",
+        "BUILD_EXAMPLES": {
+          "type": "BOOL",
+          "value": "OFF"
+        }
       }
     },
     {
@@ -104,6 +112,10 @@
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
         "BUILD_TESTING": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "BUILD_EXAMPLES": {
           "type": "BOOL",
           "value": "OFF"
         }

--- a/como/input/x11/xinput_integration.h
+++ b/como/input/x11/xinput_integration.h
@@ -27,7 +27,7 @@ namespace como::input::x11
 
 static inline qreal fixed1616ToReal(FP1616 val)
 {
-    return (val)*1.0 / (1 << 16);
+    return (val) * 1.0 / (1 << 16);
 }
 
 template<typename Xinput>

--- a/como/win/wayland/xdg_activation.h
+++ b/como/win/wayland/xdg_activation.h
@@ -63,9 +63,9 @@ inline bool generate_token(char out[token_strlen])
 template<typename Space>
 struct xdg_activation {
     xdg_activation(Space& space)
-        : interface {
-        std::make_unique<Wrapland::Server::XdgActivationV1>(space.base.server->display.get())
-    }, space{space}
+        : interface{std::make_unique<Wrapland::Server::XdgActivationV1>(
+            space.base.server->display.get())}
+        , space{space}
     {
         QObject::connect(
             interface.get(),

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -110,6 +110,7 @@ add_executable(tests
 )
 
 target_compile_definitions(tests PRIVATE USE_XWL=1)
+set_target_properties(tests PROPERTIES UNITY_BUILD ON)
 
 target_link_libraries(tests
 PRIVATE
@@ -188,6 +189,7 @@ add_executable(tests-wl
 )
 
 target_compile_definitions(tests-wl PRIVATE USE_XWL=0)
+set_target_properties(tests-wl PROPERTIES UNITY_BUILD ON)
 
 target_link_libraries(tests-wl
 PRIVATE

--- a/tests/integration/activation.cpp
+++ b/tests/integration/activation.cpp
@@ -39,7 +39,6 @@ TEST_CASE("activation", "[win]")
     SECTION("switch to left window")
     {
         // Verifies that "Switch to Window to the Left" shortcut works.
-        using namespace Wrapland::Client;
 
         // Prepare the test environment.
         stackScreensHorizontally();
@@ -107,8 +106,6 @@ TEST_CASE("activation", "[win]")
     {
         // Verifies that "Switch to Window to the Right" shortcut works.
 
-        using namespace Wrapland::Client;
-
         // Prepare the test environment.
         stackScreensHorizontally();
 
@@ -175,8 +172,6 @@ TEST_CASE("activation", "[win]")
     {
         // Verifies that "Switch to Window Above" shortcut works.
 
-        using namespace Wrapland::Client;
-
         // Prepare the test environment.
         stackScreensVertically();
 
@@ -242,8 +237,6 @@ TEST_CASE("activation", "[win]")
     SECTION("switch to bottom window")
     {
         // Verifies that "Switch to Window Bottom" shortcut works.
-
-        using namespace Wrapland::Client;
 
         // Prepare the test environment.
         stackScreensVertically();
@@ -312,8 +305,6 @@ TEST_CASE("activation", "[win]")
         // Verifies that we switch to the top-most maximized client, i.e.
         // the one that user sees at the moment. See bug 411356.
 
-        using namespace Wrapland::Client;
-
         // Prepare the test environment.
         stackScreensHorizontally();
 
@@ -324,7 +315,8 @@ TEST_CASE("activation", "[win]")
         REQUIRE(client1);
         REQUIRE(client1->control->active);
 
-        QSignalSpy configureRequestedSpy1(shellSurface1.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy1(shellSurface1.get(),
+                                          &Wrapland::Client::XdgShellToplevel::configured);
         REQUIRE(configureRequestedSpy1.isValid());
 
         REQUIRE(configureRequestedSpy1.wait());
@@ -348,7 +340,8 @@ TEST_CASE("activation", "[win]")
         REQUIRE(client2);
         REQUIRE(client2->control->active);
 
-        QSignalSpy configureRequestedSpy2(shellSurface2.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy2(shellSurface2.get(),
+                                          &Wrapland::Client::XdgShellToplevel::configured);
         REQUIRE(configureRequestedSpy2.isValid());
 
         REQUIRE(configureRequestedSpy2.wait());
@@ -415,8 +408,6 @@ TEST_CASE("activation", "[win]")
         // Verifies that we switch to the top-most fullscreen fullscreen, i.e.
         // the one that user sees at the moment. See bug 411356.
 
-        using namespace Wrapland::Client;
-
         // Prepare the test environment.
         stackScreensVertically();
 
@@ -427,7 +418,8 @@ TEST_CASE("activation", "[win]")
         REQUIRE(client1);
         REQUIRE(client1->control->active);
 
-        QSignalSpy configureRequestedSpy1(shellSurface1.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy1(shellSurface1.get(),
+                                          &Wrapland::Client::XdgShellToplevel::configured);
         REQUIRE(configureRequestedSpy1.isValid());
 
         REQUIRE(configureRequestedSpy1.wait());
@@ -449,7 +441,8 @@ TEST_CASE("activation", "[win]")
         REQUIRE(client2);
         REQUIRE(client2->control->active);
 
-        QSignalSpy configureRequestedSpy2(shellSurface2.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy2(shellSurface2.get(),
+                                          &Wrapland::Client::XdgShellToplevel::configured);
         REQUIRE(configureRequestedSpy2.isValid());
 
         REQUIRE(configureRequestedSpy2.wait());

--- a/tests/integration/bindings.cpp
+++ b/tests/integration/bindings.cpp
@@ -13,8 +13,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <catch2/generators/catch_generators.hpp>
 #include <catch2/generators/catch_generators_range.hpp>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 

--- a/tests/integration/buffer_size_change.cpp
+++ b/tests/integration/buffer_size_change.cpp
@@ -21,9 +21,6 @@ TEST_CASE("buffer size change", "[render]")
     SECTION("shm")
     {
         // Verifies that an SHM buffer size change is handled correctly.
-
-        using namespace Wrapland::Client;
-
         auto surface = create_surface();
         QVERIFY(surface);
 
@@ -48,8 +45,6 @@ TEST_CASE("buffer size change", "[render]")
 
     SECTION("shm on subsurface")
     {
-        using namespace Wrapland::Client;
-
         // setup parent surface
         auto parentSurface = create_surface();
         QVERIFY(parentSurface);
@@ -59,7 +54,7 @@ TEST_CASE("buffer size change", "[render]")
         // setup sub surface
         auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<SubSurface> subSurface(create_subsurface(surface, parentSurface));
+        auto subSurface = create_subsurface(surface, parentSurface);
         QVERIFY(subSurface);
 
         // set buffer sizes
@@ -74,7 +69,7 @@ TEST_CASE("buffer size change", "[render]")
         QSignalSpy damagedParentSpy(parent->qobject.get(), &win::window_qobject::damaged);
         QVERIFY(damagedParentSpy.isValid());
         render(surface, QSize(20, 10), Qt::red);
-        parentSurface->commit(Surface::CommitFlag::None);
+        parentSurface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         QVERIFY(damagedParentSpy.wait());
         QTRY_COMPARE(damagedParentSpy.count(), 2);

--- a/tests/integration/dbus_interface.cpp
+++ b/tests/integration/dbus_interface.cpp
@@ -14,8 +14,6 @@ SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
 #include <Wrapland/Client/surface.h>
 #include <xcb/xcb_icccm.h>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -60,8 +58,8 @@ TEST_CASE("dbus interface", "[base]")
                                   &space::qobject_t::wayland_window_added);
         QVERIFY(clientAddedSpy.isValid());
 
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         shellSurface->setAppId(QByteArrayLiteral("org.kde.foo"));
         shellSurface->setTitle(QStringLiteral("Test window"));
 

--- a/tests/integration/debug_console.cpp
+++ b/tests/integration/debug_console.cpp
@@ -325,11 +325,12 @@ TEST_CASE("debug console", "[debug]")
         setup_wayland_connection();
 
         // create the Surface and ShellSurface
-        using namespace Wrapland::Client;
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
+        QVERIFY(surface);
         QVERIFY(surface->isValid());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
+
         render(surface, QSize(10, 10), Qt::red);
 
         // now we have the window, it should be added to our model
@@ -388,8 +389,8 @@ TEST_CASE("debug console", "[debug]")
         QSignalSpy rowsRemovedSpy(model.get(), &QAbstractItemModel::rowsRemoved);
         QVERIFY(rowsRemovedSpy.isValid());
 
-        surface->attachBuffer(Buffer::Ptr());
-        surface->commit(Surface::CommitFlag::None);
+        surface->attachBuffer(Wrapland::Client::Buffer::Ptr());
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
         shellSurface.reset();
         flush_wayland_connection();
         QVERIFY(rowsRemovedSpy.wait(500));

--- a/tests/integration/decoration_input.cpp
+++ b/tests/integration/decoration_input.cpp
@@ -71,31 +71,29 @@ TEST_CASE("decoration input", "[input],[win]")
     } client;
 
     auto showWindow = [&]() -> space::wayland_window* {
-        using namespace Wrapland::Client;
-
 #define VERIFY(statement)                                                                          \
     if (!QTest::qVerify((statement), #statement, "", __FILE__, __LINE__))                          \
         return nullptr;
 #define COMPARE(actual, expected)                                                                  \
     if (!QTest::qCompare(actual, expected, #actual, #expected, __FILE__, __LINE__))                \
         return nullptr;
-
         client.surface = create_surface();
         VERIFY(client.surface.get());
         client.toplevel = create_xdg_shell_toplevel(client.surface, CreationSetup::CreateOnly);
         VERIFY(client.toplevel.get());
 
-        QSignalSpy configureRequestedSpy(client.toplevel.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy(client.toplevel.get(),
+                                         &Wrapland::Client::XdgShellToplevel::configured);
 
         auto deco = get_client().interfaces.xdg_decoration->getToplevelDecoration(
             client.toplevel.get(), client.toplevel.get());
-        QSignalSpy decoSpy(deco, &XdgDecoration::modeChanged);
+        QSignalSpy decoSpy(deco, &Wrapland::Client::XdgDecoration::modeChanged);
         VERIFY(decoSpy.isValid());
-        deco->setMode(XdgDecoration::Mode::ServerSide);
-        COMPARE(deco->mode(), XdgDecoration::Mode::ClientSide);
+        deco->setMode(Wrapland::Client::XdgDecoration::Mode::ServerSide);
+        COMPARE(deco->mode(), Wrapland::Client::XdgDecoration::Mode::ClientSide);
         init_xdg_shell_toplevel(client.surface, client.toplevel);
         COMPARE(decoSpy.count(), 1);
-        COMPARE(deco->mode(), XdgDecoration::Mode::ServerSide);
+        COMPARE(deco->mode(), Wrapland::Client::XdgDecoration::Mode::ServerSide);
 
         VERIFY(configureRequestedSpy.count() > 0 || configureRequestedSpy.wait());
         COMPARE(configureRequestedSpy.count(), 1);

--- a/tests/integration/effects/fade.cpp
+++ b/tests/integration/effects/fade.cpp
@@ -10,8 +10,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <Wrapland/Client/buffer.h>
 #include <Wrapland/Client/surface.h>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -64,8 +62,8 @@ TEST_CASE("fade", "[effect]")
         QSignalSpy windowClosedSpy(effects, &EffectsHandler::windowClosed);
         QVERIFY(windowClosedSpy.isValid());
 
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         auto c = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
         QVERIFY(c);
         QTRY_COMPARE(windowAddedSpy.count(), 1);
@@ -80,8 +78,8 @@ TEST_CASE("fade", "[effect]")
         QTRY_COMPARE(fade_effect->isActive(), false);
 
         // now unmap the surface
-        surface->attachBuffer(Buffer::Ptr());
-        surface->commit(Surface::CommitFlag::None);
+        surface->attachBuffer(Wrapland::Client::Buffer::Ptr());
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
         QVERIFY(windowHiddenSpy.wait());
         QCOMPARE(fade_effect->isActive(), false);
 
@@ -91,8 +89,8 @@ TEST_CASE("fade", "[effect]")
         QCOMPARE(fade_effect->isActive(), false);
 
         // and unmap once more
-        surface->attachBuffer(Buffer::Ptr());
-        surface->commit(Surface::CommitFlag::None);
+        surface->attachBuffer(Wrapland::Client::Buffer::Ptr());
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
         QVERIFY(windowHiddenSpy.wait());
         QCOMPARE(fade_effect->isActive(), false);
 

--- a/tests/integration/effects/maximize_animation.cpp
+++ b/tests/integration/effects/maximize_animation.cpp
@@ -43,19 +43,17 @@ TEST_CASE("maximize animation", "[effect]")
         // This test verifies that the maximize effect animates a client
         // when it's maximized or restored.
 
-        using namespace Wrapland::Client;
-
         // Create the test client.
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-
-        std::unique_ptr<XdgShellToplevel> shellSurface(
-            create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly));
+        auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
+        QVERIFY(shellSurface);
 
         // Wait for the initial configure event.
-        QSignalSpy configureRequestedSpy(shellSurface.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy(shellSurface.get(),
+                                         &Wrapland::Client::XdgShellToplevel::configured);
 
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         QVERIFY(configureRequestedSpy.isValid());
         QVERIFY(configureRequestedSpy.wait());
@@ -63,8 +61,8 @@ TEST_CASE("maximize animation", "[effect]")
 
         auto cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(0, 0));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Draw contents of the surface.
         shellSurface->ackConfigure(configureRequestedSpy.back().front().value<quint32>());
@@ -78,8 +76,8 @@ TEST_CASE("maximize animation", "[effect]")
         QCOMPARE(configureRequestedSpy.count(), 2);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Load effect that will be tested.
         const QString effectName = QStringLiteral("maximize");
@@ -106,8 +104,8 @@ TEST_CASE("maximize animation", "[effect]")
 
         cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(1280, 1024));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Draw contents of the maximized client.
         shellSurface->ackConfigure(configureRequestedSpy.back().front().value<quint32>());
@@ -128,8 +126,8 @@ TEST_CASE("maximize animation", "[effect]")
 
         cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(100, 50));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Draw contents of the restored client.
         shellSurface->ackConfigure(configureRequestedSpy.back().front().value<quint32>());

--- a/tests/integration/effects/minimize_animation.cpp
+++ b/tests/integration/effects/minimize_animation.cpp
@@ -50,27 +50,27 @@ TEST_CASE("minimize animation", "[effect]")
     {
         // This test verifies that a minimize effect tries to animate a client
         // when it's minimized or unminimized.
-        using namespace Wrapland::Client;
-
         auto effectName = GENERATE(QString("magiclamp"), QString("squash"));
 
         QSignalSpy plasmaWindowCreatedSpy(get_client().interfaces.window_management.get(),
-                                          &PlasmaWindowManagement::windowCreated);
+                                          &Wrapland::Client::PlasmaWindowManagement::windowCreated);
         QVERIFY(plasmaWindowCreatedSpy.isValid());
 
         // Create a panel at the top of the screen.
         const QRect panelRect = QRect(0, 0, 1280, 36);
-        std::unique_ptr<Surface> panelSurface(create_surface());
+        auto panelSurface = create_surface();
         QVERIFY(panelSurface);
-        std::unique_ptr<XdgShellToplevel> panelShellSurface(
-            create_xdg_shell_toplevel(panelSurface));
+        auto panelShellSurface = create_xdg_shell_toplevel(panelSurface);
         QVERIFY(panelShellSurface);
-        std::unique_ptr<PlasmaShellSurface> plasmaPanelShellSurface(
+
+        std::unique_ptr<Wrapland::Client::PlasmaShellSurface> plasmaPanelShellSurface(
             get_client().interfaces.plasma_shell->createSurface(panelSurface.get()));
         QVERIFY(plasmaPanelShellSurface);
-        plasmaPanelShellSurface->setRole(PlasmaShellSurface::Role::Panel);
+
+        plasmaPanelShellSurface->setRole(Wrapland::Client::PlasmaShellSurface::Role::Panel);
         plasmaPanelShellSurface->setPosition(panelRect.topLeft());
-        plasmaPanelShellSurface->setPanelBehavior(PlasmaShellSurface::PanelBehavior::AlwaysVisible);
+        plasmaPanelShellSurface->setPanelBehavior(
+            Wrapland::Client::PlasmaShellSurface::PanelBehavior::AlwaysVisible);
         auto panel = render_and_wait_for_shown(panelSurface, panelRect.size(), Qt::blue);
         QVERIFY(panel);
         QVERIFY(win::is_dock(panel));
@@ -79,10 +79,11 @@ TEST_CASE("minimize animation", "[effect]")
         QCOMPARE(plasmaWindowCreatedSpy.count(), 1);
 
         // Create the test client.
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
+
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::red);
         QVERIFY(client);
         QVERIFY(plasmaWindowCreatedSpy.wait());
@@ -90,7 +91,8 @@ TEST_CASE("minimize animation", "[effect]")
 
         // We have to set the minimized geometry because the squash effect needs it,
         // otherwise it won't start animation.
-        auto window = plasmaWindowCreatedSpy.last().first().value<PlasmaWindow*>();
+        auto window
+            = plasmaWindowCreatedSpy.last().first().value<Wrapland::Client::PlasmaWindow*>();
         QVERIFY(window);
         const QRect iconRect = QRect(0, 0, 42, 36);
         window->setMinimizedGeometry(panelSurface.get(), iconRect);

--- a/tests/integration/effects/popup_open_close_animation.cpp
+++ b/tests/integration/effects/popup_open_close_animation.cpp
@@ -50,8 +50,7 @@ TEST_CASE("popup open close animation", "[effect]")
         QVERIFY(effectsImpl);
 
         // Create the main window.
-        using namespace Wrapland::Client;
-        std::unique_ptr<Surface> mainWindowSurface(create_surface());
+        auto mainWindowSurface = create_surface();
         QVERIFY(mainWindowSurface);
         auto mainWindowShellSurface = create_xdg_shell_toplevel(mainWindowSurface);
         QVERIFY(mainWindowShellSurface);
@@ -68,10 +67,10 @@ TEST_CASE("popup open close animation", "[effect]")
         QVERIFY(!effect->isActive());
 
         // Create a popup, it should be animated.
-        std::unique_ptr<Surface> popupSurface(create_surface());
+        auto popupSurface = create_surface();
         QVERIFY(popupSurface);
 
-        xdg_shell_positioner_data pos_data;
+        Wrapland::Client::xdg_shell_positioner_data pos_data;
         pos_data.size = QSize(20, 20);
         pos_data.anchor.rect = QRect(0, 0, 10, 10);
         pos_data.anchor.edge = Qt::BottomEdge | Qt::LeftEdge;
@@ -115,8 +114,7 @@ TEST_CASE("popup open close animation", "[effect]")
         QVERIFY(effectsImpl);
 
         // Create the test client.
-        using namespace Wrapland::Client;
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
@@ -167,15 +165,15 @@ TEST_CASE("popup open close animation", "[effect]")
         QVERIFY(effectsImpl);
 
         // Create the test client.
-        using namespace Wrapland::Client;
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
-        std::unique_ptr<XdgDecoration> deco(
+        std::unique_ptr<Wrapland::Client::XdgDecoration> deco(
             get_client().interfaces.xdg_decoration->getToplevelDecoration(shellSurface.get()));
         QVERIFY(deco);
-        deco->setMode(XdgDecoration::Mode::ServerSide);
+        deco->setMode(Wrapland::Client::XdgDecoration::Mode::ServerSide);
+
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
         QVERIFY(client);
         QVERIFY(win::decoration(client));

--- a/tests/integration/effects/scripted_effects.cpp
+++ b/tests/integration/effects/scripted_effects.cpp
@@ -146,7 +146,6 @@ TEST_CASE("scripted effects", "[effect]")
         // trigger windowAdded signal
 
         // create a window
-        using namespace Wrapland::Client;
         auto surface = create_surface();
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);
@@ -220,7 +219,6 @@ TEST_CASE("scripted effects", "[effect]")
         QVERIFY(effect->load(QString::fromStdString(test_data.file)));
 
         // animated after window added connect
-        using namespace Wrapland::Client;
         auto surface = create_surface();
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);
@@ -326,7 +324,6 @@ TEST_CASE("scripted effects", "[effect]")
         QSignalSpy isActiveFullScreenEffectSpyOther(
             effectOther, &scripting::effect::isActiveFullScreenEffectChanged);
 
-        using namespace Wrapland::Client;
         auto surface = create_surface();
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);
@@ -385,7 +382,6 @@ TEST_CASE("scripted effects", "[effect]")
         QVERIFY(effect->load(QString::fromStdString(test_data.file)));
 
         // create a window
-        using namespace Wrapland::Client;
         auto surface = create_surface();
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);
@@ -432,7 +428,6 @@ TEST_CASE("scripted effects", "[effect]")
         QVERIFY(effect->load(QStringLiteral("grabTest")));
 
         // create test client
-        using namespace Wrapland::Client;
         auto surface = create_surface();
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);
@@ -465,7 +460,6 @@ TEST_CASE("scripted effects", "[effect]")
         QVERIFY(grabber->load(QStringLiteral("grabAlreadyGrabbedWindowTest_grabber")));
 
         // create test client
-        using namespace Wrapland::Client;
         auto surface = create_surface();
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);
@@ -502,7 +496,6 @@ TEST_CASE("scripted effects", "[effect]")
         QVERIFY(thief->load(QStringLiteral("grabAlreadyGrabbedWindowForcedTest_thief")));
 
         // create test client
-        using namespace Wrapland::Client;
         auto surface = create_surface();
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);
@@ -533,7 +526,6 @@ TEST_CASE("scripted effects", "[effect]")
         QVERIFY(effect->load(QStringLiteral("ungrabTest")));
 
         // create test client
-        using namespace Wrapland::Client;
         auto surface = create_surface();
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);
@@ -574,7 +566,6 @@ TEST_CASE("scripted effects", "[effect]")
         QVERIFY(effect->load(test_data.file));
 
         // create test client
-        using namespace Wrapland::Client;
         auto surface = create_surface();
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);
@@ -651,7 +642,6 @@ TEST_CASE("scripted effects", "[effect]")
         QVERIFY(effect->load(QStringLiteral("completeTest")));
 
         // create test client
-        using namespace Wrapland::Client;
         auto surface = create_surface();
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);

--- a/tests/integration/effects/slidingpopups.cpp
+++ b/tests/integration/effects/slidingpopups.cpp
@@ -239,26 +239,27 @@ TEST_CASE("slidingpopups", "[effect]")
         QSignalSpy windowAddedSpy(effects, &EffectsHandler::windowAdded);
         QVERIFY(windowAddedSpy.isValid());
 
-        using namespace Wrapland::Client;
         // the test created the slide protocol, let's create a Registry and listen for it
-        std::unique_ptr<Registry> registry(new Registry);
+        std::unique_ptr<Wrapland::Client::Registry> registry(new Wrapland::Client::Registry);
         registry->create(get_client().connection);
 
-        QSignalSpy interfacesAnnouncedSpy(registry.get(), &Registry::interfacesAnnounced);
+        QSignalSpy interfacesAnnouncedSpy(registry.get(),
+                                          &Wrapland::Client::Registry::interfacesAnnounced);
         QVERIFY(interfacesAnnouncedSpy.isValid());
         registry->setup();
         QVERIFY(interfacesAnnouncedSpy.wait());
-        auto slideInterface = registry->interface(Registry::Interface::Slide);
+        auto slideInterface = registry->interface(Wrapland::Client::Registry::Interface::Slide);
         QVERIFY(slideInterface.name != 0);
-        std::unique_ptr<SlideManager> slideManager(
+        std::unique_ptr<Wrapland::Client::SlideManager> slideManager(
             registry->createSlideManager(slideInterface.name, slideInterface.version));
         QVERIFY(slideManager);
 
         // create Wayland window
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<Slide> slide(slideManager->createSlide(surface.get()));
-        slide->setLocation(Slide::Location::Left);
+
+        std::unique_ptr<Wrapland::Client::Slide> slide(slideManager->createSlide(surface.get()));
+        slide->setLocation(Wrapland::Client::Slide::Location::Left);
         slide->commit();
         auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);

--- a/tests/integration/effects/subspace_switching_animation.cpp
+++ b/tests/integration/effects/subspace_switching_animation.cpp
@@ -17,8 +17,6 @@ TEST_CASE("subspace switching animation", "[effect]")
 {
     // This test verifies that subspace switching animation effects actually
     // try to animate switching between subspaces.
-    using namespace Wrapland::Client;
-
     auto effectName = GENERATE(QString("cubeslide"), QString("fadedesktop"), QString("slide"));
 
     qputenv("KWIN_COMPOSE", QByteArrayLiteral("O2"));
@@ -52,10 +50,11 @@ TEST_CASE("subspace switching animation", "[effect]")
 
     // The Fade Desktop effect will do nothing if there are no clients to fade,
     // so we have to create a dummy test client.
-    std::unique_ptr<Surface> surface(create_surface());
+    auto surface = create_surface();
     QVERIFY(surface);
-    std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+    auto shellSurface = create_xdg_shell_toplevel(surface);
     QVERIFY(shellSurface);
+
     auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
     QVERIFY(client);
     QCOMPARE(client->topo.subspaces.size(), 1);

--- a/tests/integration/effects/window_open_close_animation.cpp
+++ b/tests/integration/effects/window_open_close_animation.cpp
@@ -62,11 +62,11 @@ TEST_CASE("window open close animation", "[effect]")
         QVERIFY(!effect->isActive());
 
         // Create the test client.
-        using namespace Wrapland::Client;
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
+
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
         QVERIFY(client);
         QVERIFY(effect->isActive());
@@ -98,12 +98,11 @@ TEST_CASE("window open close animation", "[effect]")
         QVERIFY(effectsImpl);
 
         // Create the main window.
-        using namespace Wrapland::Client;
-        std::unique_ptr<Surface> mainWindowSurface(create_surface());
+        auto mainWindowSurface = create_surface();
         QVERIFY(mainWindowSurface);
-        std::unique_ptr<XdgShellToplevel> mainWindowShellSurface(
-            create_xdg_shell_toplevel(mainWindowSurface));
+        auto mainWindowShellSurface = create_xdg_shell_toplevel(mainWindowSurface);
         QVERIFY(mainWindowShellSurface);
+
         auto mainWindow = render_and_wait_for_shown(mainWindowSurface, QSize(100, 50), Qt::blue);
         QVERIFY(mainWindow);
 
@@ -117,7 +116,7 @@ TEST_CASE("window open close animation", "[effect]")
         QVERIFY(!effect->isActive());
 
         // Create a popup, it should not be animated.
-        std::unique_ptr<Surface> popupSurface(create_surface());
+        auto popupSurface = create_surface();
         QVERIFY(popupSurface);
 
         Wrapland::Client::xdg_shell_positioner_data pos_data;
@@ -126,8 +125,8 @@ TEST_CASE("window open close animation", "[effect]")
         pos_data.anchor.edge = Qt::BottomEdge | Qt::LeftEdge;
         pos_data.gravity = Qt::BottomEdge | Qt::RightEdge;
 
-        std::unique_ptr<XdgShellPopup> popupShellSurface(
-            create_xdg_shell_popup(popupSurface, mainWindowShellSurface, pos_data));
+        auto popupShellSurface
+            = create_xdg_shell_popup(popupSurface, mainWindowShellSurface, pos_data);
         QVERIFY(popupShellSurface);
         auto popup = render_and_wait_for_shown(popupSurface, pos_data.size, Qt::red);
         QVERIFY(popup);

--- a/tests/integration/global_shortcuts.cpp
+++ b/tests/integration/global_shortcuts.cpp
@@ -15,8 +15,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <linux/input.h>
 #include <xcb/xcb_icccm.h>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -187,8 +185,8 @@ TEST_CASE("global shortcuts", "[input]")
         //   * https://github.com/xkbcommon/libxkbcommon/issues/17
 
         // first create a window
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(surface);
         QVERIFY(shellSurface);
 
@@ -388,8 +386,8 @@ TEST_CASE("global shortcuts", "[input]")
 
     SECTION("wayland window shortcut")
     {
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
 
         QCOMPARE(get_wayland_window(setup.base->mod.space->stacking.active), client);
@@ -434,9 +432,9 @@ TEST_CASE("global shortcuts", "[input]")
     {
         // QTBUG-62102
 
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
         QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
 
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);

--- a/tests/integration/idle.cpp
+++ b/tests/integration/idle.cpp
@@ -103,12 +103,11 @@ TEST_CASE("idle", "[input]")
     {
         struct notification_wrap {
             notification_wrap(uint32_t duration)
-                : interface {
-                get_client().interfaces.idle_notifier->get_notification(
+                : interface{get_client().interfaces.idle_notifier->get_notification(
                     duration,
-                    get_client().interfaces.seat.get())
-            }, idle_spy{interface.get(), &Wrapland::Client::idle_notification_v1::idled},
-                resume_spy{interface.get(), &Wrapland::Client::idle_notification_v1::resumed}
+                    get_client().interfaces.seat.get())}
+                , idle_spy{interface.get(), &Wrapland::Client::idle_notification_v1::idled}
+                , resume_spy{interface.get(), &Wrapland::Client::idle_notification_v1::resumed}
             {
             }
 

--- a/tests/integration/idle_inhibition.cpp
+++ b/tests/integration/idle_inhibition.cpp
@@ -13,8 +13,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <Wrapland/Server/display.h>
 #include <Wrapland/Server/kde_idle.h>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -32,8 +30,10 @@ TEST_CASE("idle inhibition", "[win]")
         QCOMPARE(idle.inhibit_count, 0);
 
         // now create window
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
+        QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
+        QVERIFY(shellSurface);
 
         auto notification = std::unique_ptr<Wrapland::Client::idle_notification_v1>(
             get_client().interfaces.idle_notifier->get_notification(
@@ -49,7 +49,7 @@ TEST_CASE("idle inhibition", "[win]")
         QVERIFY(idle_spy.wait());
 
         // now create inhibition on window
-        std::unique_ptr<IdleInhibitor> inhibitor(
+        std::unique_ptr<Wrapland::Client::IdleInhibitor> inhibitor(
             get_client().interfaces.idle_inhibit->createInhibitor(surface.get()));
         QVERIFY(inhibitor->isValid());
 
@@ -104,13 +104,13 @@ TEST_CASE("idle inhibition", "[win]")
         QCOMPARE(idle.inhibit_count, 0);
 
         // Create the test client.
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
 
         // Create the inhibitor object.
-        std::unique_ptr<IdleInhibitor> inhibitor(
+        std::unique_ptr<Wrapland::Client::IdleInhibitor> inhibitor(
             get_client().interfaces.idle_inhibit->createInhibitor(surface.get()));
         QVERIFY(inhibitor->isValid());
 
@@ -155,13 +155,13 @@ TEST_CASE("idle inhibition", "[win]")
         QCOMPARE(idle.inhibit_count, 0);
 
         // Create the test client.
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
 
         // Create the inhibitor object.
-        std::unique_ptr<IdleInhibitor> inhibitor(
+        std::unique_ptr<Wrapland::Client::IdleInhibitor> inhibitor(
             get_client().interfaces.idle_inhibit->createInhibitor(surface.get()));
         QVERIFY(inhibitor->isValid());
 
@@ -196,13 +196,13 @@ TEST_CASE("idle inhibition", "[win]")
         QCOMPARE(idle.inhibit_count, 0);
 
         // Create the test client.
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
 
         // Create the inhibitor object.
-        std::unique_ptr<IdleInhibitor> inhibitor(
+        std::unique_ptr<Wrapland::Client::IdleInhibitor> inhibitor(
             get_client().interfaces.idle_inhibit->createInhibitor(surface.get()));
         QVERIFY(inhibitor->isValid());
 
@@ -216,8 +216,8 @@ TEST_CASE("idle inhibition", "[win]")
         // Unmap the client.
         QSignalSpy hiddenSpy(c->qobject.get(), &win::window_qobject::windowHidden);
         QVERIFY(hiddenSpy.isValid());
-        surface->attachBuffer(Buffer::Ptr());
-        surface->commit(Surface::CommitFlag::None);
+        surface->attachBuffer(Wrapland::Client::Buffer::Ptr());
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
         QVERIFY(hiddenSpy.wait());
 
         // The surface is no longer visible, so the compositor don't have to honor the
@@ -254,13 +254,13 @@ TEST_CASE("idle inhibition", "[win]")
         QCOMPARE(idle.inhibit_count, 0);
 
         // Create the test client.
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
 
         // Create the inhibitor object.
-        std::unique_ptr<IdleInhibitor> inhibitor(
+        std::unique_ptr<Wrapland::Client::IdleInhibitor> inhibitor(
             get_client().interfaces.idle_inhibit->createInhibitor(surface.get()));
         QVERIFY(inhibitor->isValid());
 

--- a/tests/integration/input_stacking_order.cpp
+++ b/tests/integration/input_stacking_order.cpp
@@ -49,15 +49,15 @@ TEST_CASE("input stacking order", "[win]")
         // the pointer is in the overlapping area which means the top most window has focus
         // as soon as the top most window gets lowered the window should lose focus and the
         // other window should gain focus without a mouse event in between
-        using namespace Wrapland::Client;
+
         // create pointer and signal spy for enter and leave signals
         auto seat = get_client().interfaces.seat.get();
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy enteredSpy(pointer, &Pointer::entered);
+        QSignalSpy enteredSpy(pointer, &Wrapland::Client::Pointer::entered);
         QVERIFY(enteredSpy.isValid());
-        QSignalSpy leftSpy(pointer, &Pointer::left);
+        QSignalSpy leftSpy(pointer, &Wrapland::Client::Pointer::left);
         QVERIFY(leftSpy.isValid());
 
         // now create the two windows and make them overlap

--- a/tests/integration/internal_window.cpp
+++ b/tests/integration/internal_window.cpp
@@ -16,7 +16,8 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <catch2/generators/catch_generators.hpp>
 #include <linux/input.h>
 
-using namespace Wrapland::Client;
+namespace como::detail::test::internal_window
+{
 
 namespace
 {
@@ -127,9 +128,6 @@ void HelperWindow::keyReleaseEvent(QKeyEvent* event)
 }
 
 }
-
-namespace como::detail::test
-{
 
 TEST_CASE("internal window", "[win]")
 {
@@ -326,15 +324,17 @@ TEST_CASE("internal window", "[win]")
     {
         // this test verifies that a leave event is sent to a client when an internal window
         // gets a key event
-        std::unique_ptr<Keyboard> keyboard(get_client().interfaces.seat->createKeyboard());
+        std::unique_ptr<Wrapland::Client::Keyboard> keyboard(
+            get_client().interfaces.seat->createKeyboard());
         QVERIFY(keyboard);
         QVERIFY(keyboard->isValid());
-        QSignalSpy enteredSpy(keyboard.get(), &Keyboard::entered);
+        QSignalSpy enteredSpy(keyboard.get(), &Wrapland::Client::Keyboard::entered);
         QVERIFY(enteredSpy.isValid());
-        QSignalSpy leftSpy(keyboard.get(), &Keyboard::left);
+        QSignalSpy leftSpy(keyboard.get(), &Wrapland::Client::Keyboard::left);
         QVERIFY(leftSpy.isValid());
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+
+        auto surface = create_surface();
+        auto shellSurface = create_xdg_shell_toplevel(surface);
 
         // now let's render
         auto c = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);

--- a/tests/integration/keymap_creation_failure.cpp
+++ b/tests/integration/keymap_creation_failure.cpp
@@ -9,8 +9,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <KConfigGroup>
 #include <linux/input.h>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 

--- a/tests/integration/layer_shell.cpp
+++ b/tests/integration/layer_shell.cpp
@@ -10,10 +10,10 @@
 #include <Wrapland/Client/surface.h>
 #include <catch2/generators/catch_generators.hpp>
 
-namespace Clt = Wrapland::Client;
-
-namespace como::detail::test
+namespace como::detail::test::layer_shell
 {
+
+namespace Clt = Wrapland::Client;
 
 namespace
 {

--- a/tests/integration/lockscreen.cpp
+++ b/tests/integration/lockscreen.cpp
@@ -27,9 +27,7 @@ namespace
 
 void unlock()
 {
-    using namespace ScreenLocker;
-
-    const auto children = KSldApp::self()->children();
+    const auto children = ScreenLocker::KSldApp::self()->children();
     for (auto it = children.begin(); it != children.end(); ++it) {
         if (qstrcmp((*it)->metaObject()->className(), "LogindIntegration") != 0) {
             continue;
@@ -128,8 +126,6 @@ TEST_CASE("lockscreen", "[base]")
     std::unique_ptr<Wrapland::Client::XdgShellToplevel> toplevel_holder;
 
     auto showWindow = [&]() {
-        using namespace Wrapland::Client;
-
         surface_holder = create_surface();
         REQUIRE(surface_holder.get());
         toplevel_holder = create_xdg_shell_toplevel(surface_holder);
@@ -164,13 +160,12 @@ TEST_CASE("lockscreen", "[base]")
 
     SECTION("pointer")
     {
-        using namespace Wrapland::Client;
-
-        std::unique_ptr<Pointer> pointer(get_client().interfaces.seat->createPointer());
+        std::unique_ptr<Wrapland::Client::Pointer> pointer(
+            get_client().interfaces.seat->createPointer());
         QVERIFY(pointer);
 
-        QSignalSpy enteredSpy(pointer.get(), &Pointer::entered);
-        QSignalSpy leftSpy(pointer.get(), &Pointer::left);
+        QSignalSpy enteredSpy(pointer.get(), &Wrapland::Client::Pointer::entered);
+        QSignalSpy leftSpy(pointer.get(), &Wrapland::Client::Pointer::left);
         QVERIFY(leftSpy.isValid());
         QVERIFY(enteredSpy.isValid());
 
@@ -212,13 +207,12 @@ TEST_CASE("lockscreen", "[base]")
 
     SECTION("pointer button")
     {
-        using namespace Wrapland::Client;
-
-        std::unique_ptr<Pointer> pointer(get_client().interfaces.seat->createPointer());
+        std::unique_ptr<Wrapland::Client::Pointer> pointer(
+            get_client().interfaces.seat->createPointer());
         QVERIFY(pointer);
 
-        QSignalSpy enteredSpy(pointer.get(), &Pointer::entered);
-        QSignalSpy buttonChangedSpy(pointer.get(), &Pointer::buttonStateChanged);
+        QSignalSpy enteredSpy(pointer.get(), &Wrapland::Client::Pointer::entered);
+        QSignalSpy buttonChangedSpy(pointer.get(), &Wrapland::Client::Pointer::buttonStateChanged);
         QVERIFY(enteredSpy.isValid());
         QVERIFY(buttonChangedSpy.isValid());
 
@@ -256,13 +250,12 @@ TEST_CASE("lockscreen", "[base]")
 
     SECTION("pointer axis")
     {
-        using namespace Wrapland::Client;
-
-        std::unique_ptr<Pointer> pointer(get_client().interfaces.seat->createPointer());
+        std::unique_ptr<Wrapland::Client::Pointer> pointer(
+            get_client().interfaces.seat->createPointer());
         QVERIFY(pointer);
 
-        QSignalSpy axisChangedSpy(pointer.get(), &Pointer::axisChanged);
-        QSignalSpy enteredSpy(pointer.get(), &Pointer::entered);
+        QSignalSpy axisChangedSpy(pointer.get(), &Wrapland::Client::Pointer::axisChanged);
+        QSignalSpy enteredSpy(pointer.get(), &Wrapland::Client::Pointer::entered);
         QVERIFY(axisChangedSpy.isValid());
         QVERIFY(enteredSpy.isValid());
 
@@ -299,14 +292,13 @@ TEST_CASE("lockscreen", "[base]")
 
     SECTION("keyboard")
     {
-        using namespace Wrapland::Client;
-
-        std::unique_ptr<Keyboard> keyboard(get_client().interfaces.seat->createKeyboard());
+        std::unique_ptr<Wrapland::Client::Keyboard> keyboard(
+            get_client().interfaces.seat->createKeyboard());
         QVERIFY(keyboard);
 
-        QSignalSpy enteredSpy(keyboard.get(), &Keyboard::entered);
-        QSignalSpy leftSpy(keyboard.get(), &Keyboard::left);
-        QSignalSpy keyChangedSpy(keyboard.get(), &Keyboard::keyChanged);
+        QSignalSpy enteredSpy(keyboard.get(), &Wrapland::Client::Keyboard::entered);
+        QSignalSpy leftSpy(keyboard.get(), &Wrapland::Client::Keyboard::left);
+        QSignalSpy keyChangedSpy(keyboard.get(), &Wrapland::Client::Keyboard::keyChanged);
         QVERIFY(enteredSpy.isValid());
         QVERIFY(leftSpy.isValid());
         QVERIFY(keyChangedSpy.isValid());
@@ -322,16 +314,16 @@ TEST_CASE("lockscreen", "[base]")
         QVERIFY(keyChangedSpy.wait());
         QCOMPARE(keyChangedSpy.count(), 1);
         QCOMPARE(keyChangedSpy.at(0).at(0).value<quint32>(), quint32(KEY_A));
-        QCOMPARE(keyChangedSpy.at(0).at(1).value<Keyboard::KeyState>(),
-                 Keyboard::KeyState::Pressed);
+        QCOMPARE(keyChangedSpy.at(0).at(1).value<Wrapland::Client::Keyboard::KeyState>(),
+                 Wrapland::Client::Keyboard::KeyState::Pressed);
         QCOMPARE(keyChangedSpy.at(0).at(2).value<quint32>(), quint32(1));
 
         KEYRELEASE(KEY_A);
         QVERIFY(keyChangedSpy.wait());
         QCOMPARE(keyChangedSpy.count(), 2);
         QCOMPARE(keyChangedSpy.at(1).at(0).value<quint32>(), quint32(KEY_A));
-        QCOMPARE(keyChangedSpy.at(1).at(1).value<Keyboard::KeyState>(),
-                 Keyboard::KeyState::Released);
+        QCOMPARE(keyChangedSpy.at(1).at(1).value<Wrapland::Client::Keyboard::KeyState>(),
+                 Wrapland::Client::Keyboard::KeyState::Released);
         QCOMPARE(keyChangedSpy.at(1).at(2).value<quint32>(), quint32(2));
 
         LOCK QVERIFY(leftSpy.wait());
@@ -356,10 +348,10 @@ TEST_CASE("lockscreen", "[base]")
         QCOMPARE(keyChangedSpy.at(3).at(0).value<quint32>(), quint32(KEY_C));
         QCOMPARE(keyChangedSpy.at(2).at(2).value<quint32>(), quint32(5));
         QCOMPARE(keyChangedSpy.at(3).at(2).value<quint32>(), quint32(6));
-        QCOMPARE(keyChangedSpy.at(2).at(1).value<Keyboard::KeyState>(),
-                 Keyboard::KeyState::Pressed);
-        QCOMPARE(keyChangedSpy.at(3).at(1).value<Keyboard::KeyState>(),
-                 Keyboard::KeyState::Released);
+        QCOMPARE(keyChangedSpy.at(2).at(1).value<Wrapland::Client::Keyboard::KeyState>(),
+                 Wrapland::Client::Keyboard::KeyState::Pressed);
+        QCOMPARE(keyChangedSpy.at(3).at(1).value<Wrapland::Client::Keyboard::KeyState>(),
+                 Wrapland::Client::Keyboard::KeyState::Released);
     }
 
     SECTION("screen edge")
@@ -509,8 +501,6 @@ TEST_CASE("lockscreen", "[base]")
 
     SECTION("move window")
     {
-        using namespace Wrapland::Client;
-
         auto c = showWindow();
         QVERIFY(c);
 
@@ -556,8 +546,6 @@ TEST_CASE("lockscreen", "[base]")
 
     SECTION("pointer shortcut")
     {
-        using namespace Wrapland::Client;
-
         std::unique_ptr<QAction> action(new QAction(nullptr));
         QSignalSpy actionSpy(action.get(), &QAction::triggered);
         QVERIFY(actionSpy.isValid());
@@ -590,8 +578,6 @@ TEST_CASE("lockscreen", "[base]")
 
     SECTION("axis shortcut")
     {
-        using namespace Wrapland::Client;
-
         auto direction = GENERATE(Qt::Vertical, Qt::Horizontal);
         auto sign = GENERATE(-1, 1);
 
@@ -640,8 +626,6 @@ TEST_CASE("lockscreen", "[base]")
 
     SECTION("keyboard shortcut")
     {
-        using namespace Wrapland::Client;
-
         std::unique_ptr<QAction> action(new QAction(nullptr));
         QSignalSpy actionSpy(action.get(), &QAction::triggered);
         QVERIFY(actionSpy.isValid());
@@ -695,8 +679,6 @@ TEST_CASE("lockscreen", "[base]")
 
     SECTION("touch")
     {
-        using namespace Wrapland::Client;
-
         auto touch = get_client().interfaces.seat->createTouch(get_client().interfaces.seat.get());
         QVERIFY(touch);
         QVERIFY(touch->isValid());
@@ -704,11 +686,11 @@ TEST_CASE("lockscreen", "[base]")
         auto c = showWindow();
         QVERIFY(c);
 
-        QSignalSpy sequenceStartedSpy(touch, &Touch::sequenceStarted);
+        QSignalSpy sequenceStartedSpy(touch, &Wrapland::Client::Touch::sequenceStarted);
         QVERIFY(sequenceStartedSpy.isValid());
-        QSignalSpy cancelSpy(touch, &Touch::sequenceCanceled);
+        QSignalSpy cancelSpy(touch, &Wrapland::Client::Touch::sequenceCanceled);
         QVERIFY(cancelSpy.isValid());
-        QSignalSpy pointRemovedSpy(touch, &Touch::pointRemoved);
+        QSignalSpy pointRemovedSpy(touch, &Wrapland::Client::Touch::pointRemoved);
         QVERIFY(pointRemovedSpy.isValid());
 
         quint32 timestamp = 1;

--- a/tests/integration/maximize.cpp
+++ b/tests/integration/maximize.cpp
@@ -17,8 +17,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <Wrapland/Server/xdg_decoration.h>
 #include <catch2/generators/catch_generators.hpp>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -141,23 +139,23 @@ TEST_CASE("maximize", "[win]")
         // This test verifies that a window created as maximized, will be maximized.
 
         // Create the test client.
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(
-            create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly));
+        auto surface = create_surface();
+        auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
 
-        QSignalSpy configureRequestedSpy(shellSurface.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy(shellSurface.get(),
+                                         &Wrapland::Client::XdgShellToplevel::configured);
         QVERIFY(configureRequestedSpy.isValid());
 
         shellSurface->setMaximized(true);
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         // Wait for the initial configure event.
         QVERIFY(configureRequestedSpy.wait());
         QCOMPARE(configureRequestedSpy.count(), 1);
 
         auto cfgdata = shellSurface->get_configure_data();
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Now let's render in an incorrect size.
         shellSurface->ackConfigure(configureRequestedSpy.back().front().value<quint32>());
@@ -187,22 +185,23 @@ TEST_CASE("maximize", "[win]")
         QCOMPARE(setup.base->mod.space->options->qobject->borderlessMaximizedWindows(), true);
 
         // Create the test client.
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(
-            create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly));
-        std::unique_ptr<XdgDecoration> decoration(
+        auto surface = create_surface();
+        auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
+        std::unique_ptr<Wrapland::Client::XdgDecoration> decoration(
             get_client().interfaces.xdg_decoration->getToplevelDecoration(shellSurface.get()));
 
-        QSignalSpy configureRequestedSpy(shellSurface.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy(shellSurface.get(),
+                                         &Wrapland::Client::XdgShellToplevel::configured);
         QVERIFY(configureRequestedSpy.isValid());
 
         shellSurface->setMaximized(true);
 
-        QSignalSpy decorationConfiguredSpy(decoration.get(), &XdgDecoration::modeChanged);
+        QSignalSpy decorationConfiguredSpy(decoration.get(),
+                                           &Wrapland::Client::XdgDecoration::modeChanged);
         QVERIFY(decorationConfiguredSpy.isValid());
 
-        decoration->setMode(XdgDecoration::Mode::ServerSide);
-        surface->commit(Surface::CommitFlag::None);
+        decoration->setMode(Wrapland::Client::XdgDecoration::Mode::ServerSide);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         // Wait for the initial configure event.
         QVERIFY(configureRequestedSpy.wait());
@@ -210,8 +209,8 @@ TEST_CASE("maximize", "[win]")
 
         auto cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(1280, 1024));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         shellSurface->ackConfigure(configureRequestedSpy.back().front().value<quint32>());
         auto client = render_and_wait_for_shown(surface, QSize(1280, 1024), Qt::blue);
@@ -224,7 +223,7 @@ TEST_CASE("maximize", "[win]")
         QCOMPARE(client->geo.frame, QRect(0, 0, 1280, 1024));
 
         QTRY_VERIFY(decorationConfiguredSpy.count());
-        QCOMPARE(decoration->mode(), XdgDecoration::Mode::ServerSide);
+        QCOMPARE(decoration->mode(), Wrapland::Client::XdgDecoration::Mode::ServerSide);
 
         // Destroy the client.
         shellSurface.reset();
@@ -348,12 +347,13 @@ TEST_CASE("maximize", "[win]")
         win::space_reconfigure(*setup.base->mod.space);
         QCOMPARE(setup.base->mod.space->options->qobject->borderlessMaximizedWindows(), true);
 
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> xdgShellToplevel(create_xdg_shell_toplevel(surface));
-        std::unique_ptr<XdgDecoration> deco(
+        auto surface = create_surface();
+        auto xdgShellToplevel = create_xdg_shell_toplevel(surface);
+        std::unique_ptr<Wrapland::Client::XdgDecoration> deco(
             get_client().interfaces.xdg_decoration->getToplevelDecoration(xdgShellToplevel.get()));
 
-        QSignalSpy decorationConfiguredSpy(deco.get(), &XdgDecoration::modeChanged);
+        QSignalSpy decorationConfiguredSpy(deco.get(),
+                                           &Wrapland::Client::XdgDecoration::modeChanged);
         QVERIFY(decorationConfiguredSpy.isValid());
 
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
@@ -361,7 +361,8 @@ TEST_CASE("maximize", "[win]")
         QSignalSpy geometryChangedSpy(client->qobject.get(),
                                       &win::window_qobject::frame_geometry_changed);
         QVERIFY(geometryChangedSpy.isValid());
-        QSignalSpy configureRequestedSpy(xdgShellToplevel.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy(xdgShellToplevel.get(),
+                                         &Wrapland::Client::XdgShellToplevel::configured);
         QVERIFY(configureRequestedSpy.isValid());
 
         QVERIFY(win::decoration(client));
@@ -371,8 +372,9 @@ TEST_CASE("maximize", "[win]")
         QCOMPARE(decorationConfiguredSpy.count(), 1);
 
         auto cfgdata = xdgShellToplevel->get_configure_data();
-        QVERIFY(cfgdata.updates.testFlag(xdg_shell_toplevel_configure_change::size));
-        QCOMPARE(deco->mode(), XdgDecoration::Mode::ServerSide);
+        QVERIFY(
+            cfgdata.updates.testFlag(Wrapland::Client::xdg_shell_toplevel_configure_change::size));
+        QCOMPARE(deco->mode(), Wrapland::Client::XdgDecoration::Mode::ServerSide);
 
         // go to maximized
         xdgShellToplevel->setMaximized(true);
@@ -380,7 +382,8 @@ TEST_CASE("maximize", "[win]")
         QCOMPARE(configureRequestedSpy.count(), 2);
 
         cfgdata = xdgShellToplevel->get_configure_data();
-        QVERIFY(cfgdata.updates.testFlag(xdg_shell_toplevel_configure_change::size));
+        QVERIFY(
+            cfgdata.updates.testFlag(Wrapland::Client::xdg_shell_toplevel_configure_change::size));
 
         for (auto const& sig : configureRequestedSpy) {
             xdgShellToplevel->ackConfigure(sig.front().toInt());
@@ -393,7 +396,7 @@ TEST_CASE("maximize", "[win]")
         QVERIFY(!win::decoration(client));
         QVERIFY(client->noBorder());
         // but still server-side
-        QCOMPARE(deco->mode(), XdgDecoration::Mode::ServerSide);
+        QCOMPARE(deco->mode(), Wrapland::Client::XdgDecoration::Mode::ServerSide);
 
         // go back to normal
         xdgShellToplevel->setMaximized(false);
@@ -410,7 +413,7 @@ TEST_CASE("maximize", "[win]")
 
         QVERIFY(win::decoration(client));
         QVERIFY(!client->noBorder());
-        QCOMPARE(deco->mode(), XdgDecoration::Mode::ServerSide);
+        QCOMPARE(deco->mode(), Wrapland::Client::XdgDecoration::Mode::ServerSide);
     }
 }
 

--- a/tests/integration/modifier_only_shortcut.cpp
+++ b/tests/integration/modifier_only_shortcut.cpp
@@ -13,13 +13,16 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 using namespace Wrapland::Client;
 
-static const QString s_serviceName = QStringLiteral("org.kde.KWin.Test.ModifierOnlyShortcut");
-static const QString s_path = QStringLiteral("/Test");
-static const QStringList trigger
-    = QStringList{s_serviceName, s_path, s_serviceName, QStringLiteral("shortcut")};
-
-namespace como::detail::test
+namespace como::detail::test::modifier_only_shortcut
 {
+
+namespace
+{
+
+const QString s_serviceName = QStringLiteral("org.kde.KWin.Test.ModifierOnlyShortcut");
+const QString s_path = QStringLiteral("/Test");
+const QStringList trigger
+    = QStringList{s_serviceName, s_path, s_serviceName, QStringLiteral("shortcut")};
 
 class Target : public QObject
 {
@@ -54,6 +57,8 @@ Target::~Target()
 void Target::shortcut()
 {
     Q_EMIT shortcutTriggered();
+}
+
 }
 
 TEST_CASE("modifier only shortcut", "[input]")

--- a/tests/integration/modifier_only_shortcut.cpp
+++ b/tests/integration/modifier_only_shortcut.cpp
@@ -11,8 +11,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <catch2/generators/catch_generators.hpp>
 #include <linux/input.h>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test::modifier_only_shortcut
 {
 

--- a/tests/integration/move_resize_window.cpp
+++ b/tests/integration/move_resize_window.cpp
@@ -67,12 +67,9 @@ TEST_CASE("move resize window", "[win]")
 
     SECTION("move")
     {
-        using namespace Wrapland::Client;
-
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
 
         auto c = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
@@ -158,25 +155,22 @@ TEST_CASE("move resize window", "[win]")
     SECTION("resize")
     {
         // a test case which manually resizes a window
-        using namespace Wrapland::Client;
-
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-
-        std::unique_ptr<XdgShellToplevel> shellSurface(
-            create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly));
+        auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         QVERIFY(shellSurface);
 
         // Wait for the initial configure event.
-        QSignalSpy configureRequestedSpy(shellSurface.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy(shellSurface.get(),
+                                         &Wrapland::Client::XdgShellToplevel::configured);
         QVERIFY(configureRequestedSpy.isValid());
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
         QVERIFY(configureRequestedSpy.wait());
         QCOMPARE(configureRequestedSpy.count(), 1);
 
         auto cfgdata = shellSurface->get_configure_data();
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::resizing));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::resizing));
 
         // Let's render.
         shellSurface->ackConfigure(configureRequestedSpy.back().front().value<quint32>());
@@ -187,9 +181,10 @@ TEST_CASE("move resize window", "[win]")
         QCOMPARE(configureRequestedSpy.count(), 2);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::resizing));
-        QVERIFY(cfgdata.updates.testFlag(xdg_shell_toplevel_configure_change::size));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::resizing));
+        QVERIFY(
+            cfgdata.updates.testFlag(Wrapland::Client::xdg_shell_toplevel_configure_change::size));
 
         QVERIFY(c);
         QCOMPARE(get_wayland_window(setup.base->mod.space->stacking.active), c);
@@ -223,8 +218,8 @@ TEST_CASE("move resize window", "[win]")
         QCOMPARE(configureRequestedSpy.count(), 3);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::resizing));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::resizing));
 
         // Trigger a change.
         auto const cursorPos = cursor()->pos();
@@ -237,10 +232,11 @@ TEST_CASE("move resize window", "[win]")
         QCOMPARE(configureRequestedSpy.count(), 4);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::resizing));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::resizing));
         QCOMPARE(cfgdata.size, QSize(108, 50));
-        QVERIFY(cfgdata.updates.testFlag(xdg_shell_toplevel_configure_change::size));
+        QVERIFY(
+            cfgdata.updates.testFlag(Wrapland::Client::xdg_shell_toplevel_configure_change::size));
         QCOMPARE(clientStepUserMovedResizedSpy.count(), 0);
 
         // Now render new size.
@@ -260,10 +256,11 @@ TEST_CASE("move resize window", "[win]")
         QCOMPARE(configureRequestedSpy.count(), 5);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::resizing));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::resizing));
         QCOMPARE(cfgdata.size, QSize(108, 58));
-        QVERIFY(cfgdata.updates.testFlag(xdg_shell_toplevel_configure_change::size));
+        QVERIFY(
+            cfgdata.updates.testFlag(Wrapland::Client::xdg_shell_toplevel_configure_change::size));
 
         // Now render new size.
         shellSurface->ackConfigure(configureRequestedSpy.back().front().value<quint32>());
@@ -287,8 +284,8 @@ TEST_CASE("move resize window", "[win]")
         QCOMPARE(configureRequestedSpy.count(), 6);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::resizing));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::resizing));
 
         // Destroy the client.
         surface.reset();
@@ -297,8 +294,6 @@ TEST_CASE("move resize window", "[win]")
 
     SECTION("pack to")
     {
-        using namespace Wrapland::Client;
-
         struct data {
             std::string method_name;
             QRect expected_geo;
@@ -309,10 +304,9 @@ TEST_CASE("move resize window", "[win]")
                                   data{"right", {1180, 487, 100, 50}},
                                   data{"down", {590, 974, 100, 50}});
 
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
 
         // let's render
@@ -337,8 +331,6 @@ TEST_CASE("move resize window", "[win]")
 
     SECTION("pack against client")
     {
-        using namespace Wrapland::Client;
-
         struct data {
             std::string method_name;
             QRect expected_geo;
@@ -349,25 +341,25 @@ TEST_CASE("move resize window", "[win]")
                                   data{"right", {1170, 487, 100, 50}},
                                   data{"down", {590, 964, 100, 50}});
 
-        std::unique_ptr<Surface> surface1(create_surface());
+        auto surface1 = create_surface();
         QVERIFY(surface1);
-        std::unique_ptr<Surface> surface2(create_surface());
+        auto surface2 = create_surface();
         QVERIFY(surface2);
-        std::unique_ptr<Surface> surface3(create_surface());
+        auto surface3 = create_surface();
         QVERIFY(surface3);
-        std::unique_ptr<Surface> surface4(create_surface());
+        auto surface4 = create_surface();
         QVERIFY(surface4);
 
-        std::unique_ptr<XdgShellToplevel> shellSurface1(create_xdg_shell_toplevel(surface1));
+        auto shellSurface1 = create_xdg_shell_toplevel(surface1);
         QVERIFY(shellSurface1);
-        std::unique_ptr<XdgShellToplevel> shellSurface2(create_xdg_shell_toplevel(surface2));
+        auto shellSurface2 = create_xdg_shell_toplevel(surface2);
         QVERIFY(shellSurface2);
-        std::unique_ptr<XdgShellToplevel> shellSurface3(create_xdg_shell_toplevel(surface3));
+        auto shellSurface3 = create_xdg_shell_toplevel(surface3);
         QVERIFY(shellSurface3);
-        std::unique_ptr<XdgShellToplevel> shellSurface4(create_xdg_shell_toplevel(surface4));
+        auto shellSurface4 = create_xdg_shell_toplevel(surface4);
         QVERIFY(shellSurface4);
 
-        auto renderWindow = [&setup](std::unique_ptr<Surface> const& surface,
+        auto renderWindow = [&setup](auto const& surface,
                                      std::function<void(space&)> const& method_call,
                                      const QRect& expectedGeometry) {
             // let's render
@@ -387,10 +379,11 @@ TEST_CASE("move resize window", "[win]")
         renderWindow(surface3, &win::active_window_pack_right<space>, QRect(1270, 507, 10, 10));
         renderWindow(surface4, &win::active_window_pack_down<space>, QRect(635, 1014, 10, 10));
 
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
+
         auto c = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
 
         QVERIFY(c);
@@ -407,8 +400,6 @@ TEST_CASE("move resize window", "[win]")
 
     SECTION("grow shrink")
     {
-        using namespace Wrapland::Client;
-
         struct data {
             std::string method_name;
             QRect expected_geo;
@@ -421,9 +412,9 @@ TEST_CASE("move resize window", "[win]")
 
         // This helper surface ensures the test surface will shrink when calling the respective
         // methods.
-        std::unique_ptr<Surface> surface1(create_surface());
+        auto surface1 = create_surface();
         QVERIFY(surface1);
-        std::unique_ptr<XdgShellToplevel> shellSurface1(create_xdg_shell_toplevel(surface1));
+        auto shellSurface1 = create_xdg_shell_toplevel(surface1);
         QVERIFY(shellSurface1);
 
         auto window = render_and_wait_for_shown(surface1, QSize(650, 514), Qt::blue);
@@ -431,16 +422,16 @@ TEST_CASE("move resize window", "[win]")
         win::active_window_pack_right(*setup.base->mod.space);
         win::active_window_pack_down(*setup.base->mod.space);
 
-        std::unique_ptr<Surface> surface(create_surface());
-        QVERIFY(surface);
+        auto surface2 = create_surface();
+        QVERIFY(surface2);
+        auto shellSurface2 = create_xdg_shell_toplevel(surface2);
+        QVERIFY(shellSurface2);
 
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
-        QVERIFY(shellSurface);
-
-        QSignalSpy configure_spy(shellSurface.get(), &XdgShellToplevel::configured);
+        QSignalSpy configure_spy(shellSurface2.get(),
+                                 &Wrapland::Client::XdgShellToplevel::configured);
         QVERIFY(configure_spy.isValid());
 
-        auto c = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
+        auto c = render_and_wait_for_shown(surface2, QSize(100, 50), Qt::blue);
         QVERIFY(c);
         QCOMPARE(get_wayland_window(setup.base->mod.space->stacking.active), c);
 
@@ -463,8 +454,8 @@ TEST_CASE("move resize window", "[win]")
         QVERIFY(configure_spy.wait());
         QCOMPARE(configure_spy.count(), 2);
 
-        shellSurface->ackConfigure(configure_spy.back().front().value<quint32>());
-        render(surface, shellSurface->get_configure_data().size, Qt::red);
+        shellSurface2->ackConfigure(configure_spy.back().front().value<quint32>());
+        render(surface2, shellSurface2->get_configure_data().size, Qt::red);
 
         QVERIFY(geometryChangedSpy.wait());
         REQUIRE(c->geo.frame == test_data.expected_geo);
@@ -474,8 +465,6 @@ TEST_CASE("move resize window", "[win]")
     {
         // this test verifies that moving a window through pointer only ends if all buttons are
         // released
-        using namespace Wrapland::Client;
-
         auto additional_button = GENERATE(BTN_RIGHT,
                                           BTN_MIDDLE,
                                           BTN_SIDE,
@@ -485,10 +474,9 @@ TEST_CASE("move resize window", "[win]")
                                           BTN_TASK,
                                           range(BTN_TASK + 1, BTN_JOYSTICK));
 
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
 
         // let's render
@@ -522,18 +510,21 @@ TEST_CASE("move resize window", "[win]")
 
     SECTION("window side move")
     {
-        using namespace Wrapland::Client;
         cursor()->set_pos(640, 512);
-        std::unique_ptr<Pointer> pointer(get_client().interfaces.seat->createPointer());
-        QSignalSpy pointerEnteredSpy(pointer.get(), &Pointer::entered);
+        std::unique_ptr<Wrapland::Client::Pointer> pointer(
+            get_client().interfaces.seat->createPointer());
+        QSignalSpy pointerEnteredSpy(pointer.get(), &Wrapland::Client::Pointer::entered);
         QVERIFY(pointerEnteredSpy.isValid());
-        QSignalSpy pointerLeftSpy(pointer.get(), &Pointer::left);
+        QSignalSpy pointerLeftSpy(pointer.get(), &Wrapland::Client::Pointer::left);
         QVERIFY(pointerLeftSpy.isValid());
-        QSignalSpy buttonSpy(pointer.get(), &Pointer::buttonStateChanged);
+        QSignalSpy buttonSpy(pointer.get(), &Wrapland::Client::Pointer::buttonStateChanged);
         QVERIFY(buttonSpy.isValid());
 
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
+        QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
+        QVERIFY(shellSurface);
+
         auto c = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
         QVERIFY(c);
 
@@ -579,8 +570,6 @@ TEST_CASE("move resize window", "[win]")
     {
         // this test verifies that certain window types from PlasmaShellSurface are not moveable or
         // resizable
-        using namespace Wrapland::Client;
-
         struct data {
             Wrapland::Client::PlasmaShellSurface::Role role;
             bool movable;
@@ -594,13 +583,13 @@ TEST_CASE("move resize window", "[win]")
             data{Wrapland::Client::PlasmaShellSurface::Role::Panel, false, false, false},
             data{Wrapland::Client::PlasmaShellSurface::Role::OnScreenDisplay, false, false, false});
 
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
+
         // and a PlasmaShellSurface
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface(
+        std::unique_ptr<Wrapland::Client::PlasmaShellSurface> plasmaSurface(
             get_client().interfaces.plasma_shell->createSurface(surface.get()));
         QVERIFY(plasmaSurface);
         plasmaSurface->setRole(test_data.role);
@@ -779,12 +768,11 @@ TEST_CASE("move resize window", "[win]")
         QVERIFY(win::is_dock(panel));
 
         // let's create a window
-        using namespace Wrapland::Client;
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
+
         auto testWindow = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
 
         QVERIFY(testWindow);
@@ -840,8 +828,6 @@ TEST_CASE("move resize window", "[win]")
     {
         // this test verifies that auto hiding panels are ignored when adjusting client geometry
         // see BUG 365892
-        using namespace Wrapland::Client;
-
         struct data {
             QRect panel_geo;
             QPoint target_point;
@@ -856,16 +842,18 @@ TEST_CASE("move resize window", "[win]")
                        data{{1280 - 20, 0, 20, 100}, {1280 - 25 - 100, 50}, {1280 - 20 - 100, 50}});
 
         // first create our panel
-        std::unique_ptr<Surface> panelSurface(create_surface());
+        auto panelSurface = create_surface();
         QVERIFY(panelSurface);
-        std::unique_ptr<XdgShellToplevel> panelShellSurface(
-            create_xdg_shell_toplevel(panelSurface));
+        auto panelShellSurface = create_xdg_shell_toplevel(panelSurface);
         QVERIFY(panelShellSurface);
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface(
+
+        std::unique_ptr<Wrapland::Client::PlasmaShellSurface> plasmaSurface(
             get_client().interfaces.plasma_shell->createSurface(panelSurface.get()));
         QVERIFY(plasmaSurface);
-        plasmaSurface->setRole(PlasmaShellSurface::Role::Panel);
-        plasmaSurface->setPanelBehavior(PlasmaShellSurface::PanelBehavior::AutoHide);
+
+        plasmaSurface->setRole(Wrapland::Client::PlasmaShellSurface::Role::Panel);
+        plasmaSurface->setPanelBehavior(
+            Wrapland::Client::PlasmaShellSurface::PanelBehavior::AutoHide);
         plasmaSurface->setPosition(test_data.panel_geo.topLeft());
 
         // let's render
@@ -875,11 +863,11 @@ TEST_CASE("move resize window", "[win]")
         QVERIFY(win::is_dock(panel));
 
         // let's create a window
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
+
         auto testWindow = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
 
         QVERIFY(testWindow);
@@ -928,11 +916,11 @@ TEST_CASE("move resize window", "[win]")
         // the associated client is destroyed.
 
         // Create the test client.
-        using namespace Wrapland::Client;
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
+
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
         QVERIFY(client);
 
@@ -967,11 +955,11 @@ TEST_CASE("move resize window", "[win]")
         // the associated client is destroyed.
 
         // Create the test client.
-        using namespace Wrapland::Client;
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
+
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
         QVERIFY(client);
 
@@ -1006,11 +994,11 @@ TEST_CASE("move resize window", "[win]")
         // the associated client is unmapped.
 
         // Create the test client.
-        using namespace Wrapland::Client;
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
+
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
         QVERIFY(client);
 
@@ -1034,8 +1022,8 @@ TEST_CASE("move resize window", "[win]")
         // Unmap the client while we're moving it.
         QSignalSpy hiddenSpy(client->qobject.get(), &win::window_qobject::windowHidden);
         QVERIFY(hiddenSpy.isValid());
-        surface->attachBuffer(Buffer::Ptr());
-        surface->commit(Surface::CommitFlag::None);
+        surface->attachBuffer(Wrapland::Client::Buffer::Ptr());
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
         QVERIFY(hiddenSpy.wait());
         QCOMPARE(clientFinishUserMovedResizedSpy.count(), 0);
         QVERIFY(!setup.base->mod.space->move_resize_window);
@@ -1054,11 +1042,11 @@ TEST_CASE("move resize window", "[win]")
         // the associated client is unmapped.
 
         // Create the test client.
-        using namespace Wrapland::Client;
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
+
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
         QVERIFY(client);
 
@@ -1082,8 +1070,10 @@ TEST_CASE("move resize window", "[win]")
         // Unmap the client while we're resizing it.
         QSignalSpy hiddenSpy(client->qobject.get(), &win::window_qobject::windowHidden);
         QVERIFY(hiddenSpy.isValid());
-        surface->attachBuffer(Buffer::Ptr());
-        surface->commit(Surface::CommitFlag::None);
+
+        surface->attachBuffer(Wrapland::Client::Buffer::Ptr());
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
+
         QVERIFY(hiddenSpy.wait());
         QCOMPARE(clientFinishUserMovedResizedSpy.count(), 0);
         QVERIFY(!setup.base->mod.space->move_resize_window);
@@ -1099,12 +1089,9 @@ TEST_CASE("move resize window", "[win]")
     SECTION("set fullscreen while moving")
     {
         // Ensure we disable moving event when setFullScreen is triggered
-        using namespace Wrapland::Client;
-
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
 
         auto client = render_and_wait_for_shown(surface, QSize(500, 800), Qt::blue);
@@ -1112,7 +1099,8 @@ TEST_CASE("move resize window", "[win]")
 
         QSignalSpy fullscreen_spy(client->qobject.get(), &win::window_qobject::fullScreenChanged);
         QVERIFY(fullscreen_spy.isValid());
-        QSignalSpy configureRequestedSpy(shellSurface.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy(shellSurface.get(),
+                                         &Wrapland::Client::XdgShellToplevel::configured);
         QVERIFY(configureRequestedSpy.isValid());
         QVERIFY(configureRequestedSpy.wait());
 
@@ -1123,8 +1111,8 @@ TEST_CASE("move resize window", "[win]")
         QCOMPARE(configureRequestedSpy.count(), 2);
 
         auto cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::fullscreen));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::fullscreen));
 
         QCOMPARE(cfgdata.size, QSize(500, 800));
 
@@ -1136,7 +1124,7 @@ TEST_CASE("move resize window", "[win]")
         QCOMPARE(configureRequestedSpy.count(), 3);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::fullscreen));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::fullscreen));
         QCOMPARE(cfgdata.size, get_output(0)->geometry().size());
 
         shellSurface->ackConfigure(configureRequestedSpy.back().front().value<quint32>());
@@ -1158,12 +1146,9 @@ TEST_CASE("move resize window", "[win]")
     SECTION("set maximize while moving")
     {
         // Ensure we disable moving event when changeMaximize is triggered
-        using namespace Wrapland::Client;
-
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
 
         // let's render

--- a/tests/integration/no_crash_cancel_animation.cpp
+++ b/tests/integration/no_crash_cancel_animation.cpp
@@ -37,8 +37,6 @@ TEST_CASE("no crash cancel animation", "[render]")
     setup.base->mod.render->effects->loader->effectLoaded(effect, "crashy");
     QVERIFY(setup.base->mod.render->effects->isEffectLoaded(QStringLiteral("crashy")));
 
-    using namespace Wrapland::Client;
-
     // create a window
     auto surface = std::unique_ptr<Wrapland::Client::Surface>(create_surface());
     QVERIFY(surface);

--- a/tests/integration/no_crash_cursor_physical_size_empty.cpp
+++ b/tests/integration/no_crash_cursor_physical_size_empty.cpp
@@ -14,8 +14,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <Wrapland/Server/output.h>
 #include <Wrapland/Server/wl_output.h>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -41,8 +39,8 @@ TEST_CASE("no crash cursor physical size empty", "[win]")
     {
         // This test ensures that there is no endless recursion if the cursor theme cannot be
         // created a reason for creation failure could be physical size not existing see BUG: 390314
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         get_client().interfaces.xdg_decoration->getToplevelDecoration(shellSurface.get(),
                                                                       shellSurface.get());
 

--- a/tests/integration/no_crash_no_border.cpp
+++ b/tests/integration/no_crash_no_border.cpp
@@ -17,7 +17,6 @@ namespace como::detail::test
 TEST_CASE("no crash no border", "[win]")
 {
     // Create a window and ensure that this doesn't crash.
-    using namespace Wrapland::Client;
 
     // this test needs to enforce OpenGL compositing to get into the crashy condition
     qputenv("KWIN_COMPOSE", QByteArrayLiteral("O2"));
@@ -39,22 +38,21 @@ TEST_CASE("no crash no border", "[win]")
     setup_wayland_connection(global_selection::xdg_decoration);
     cursor()->set_pos(QPoint(640, 512));
 
-    std::unique_ptr<Surface> surface(create_surface());
+    auto surface = create_surface();
     QVERIFY(surface);
-    std::unique_ptr<XdgShellToplevel> shellSurface(
-        create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly));
+    auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
     QVERIFY(shellSurface);
 
     auto deco = get_client().interfaces.xdg_decoration->getToplevelDecoration(shellSurface.get(),
                                                                               shellSurface.get());
-    QSignalSpy decoSpy(deco, &XdgDecoration::modeChanged);
+    QSignalSpy decoSpy(deco, &Wrapland::Client::XdgDecoration::modeChanged);
     QVERIFY(decoSpy.isValid());
-    deco->setMode(XdgDecoration::Mode::ServerSide);
-    QCOMPARE(deco->mode(), XdgDecoration::Mode::ClientSide);
+    deco->setMode(Wrapland::Client::XdgDecoration::Mode::ServerSide);
+    QCOMPARE(deco->mode(), Wrapland::Client::XdgDecoration::Mode::ClientSide);
     init_xdg_shell_toplevel(surface, shellSurface);
 
     // Without server-side decoration available the mode set by the compositor will be client-side.
-    QCOMPARE(deco->mode(), XdgDecoration::Mode::ClientSide);
+    QCOMPARE(deco->mode(), Wrapland::Client::XdgDecoration::Mode::ClientSide);
 
     // let's render
     auto c = render_and_wait_for_shown(surface, QSize(500, 50), Qt::blue);

--- a/tests/integration/no_crash_reinitialize_compositor.cpp
+++ b/tests/integration/no_crash_reinitialize_compositor.cpp
@@ -18,8 +18,6 @@ TEST_CASE("no crash reinit compositor", "[render]")
     // This test verifies that KWin doesn't crash when the compositor settings have been changed
     // while a scripted effect animates the disappearing of a window.
 
-    using namespace Wrapland::Client;
-
     qputenv("XDG_DATA_DIRS", QCoreApplication::applicationDirPath().toUtf8());
     qputenv("COMO_EFFECTS_FORCE_ANIMATIONS", QByteArrayLiteral("1"));
     qputenv("KWIN_COMPOSE", QByteArrayLiteral("O2"));
@@ -53,9 +51,9 @@ TEST_CASE("no crash reinit compositor", "[render]")
     // Create the test client.
     setup_wayland_connection();
 
-    std::unique_ptr<Surface> surface(create_surface());
+    auto surface = create_surface();
     QVERIFY(surface);
-    std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+    auto shellSurface = create_xdg_shell_toplevel(surface);
     QVERIFY(shellSurface);
     auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
     QVERIFY(client);

--- a/tests/integration/no_crash_useractions_menu.cpp
+++ b/tests/integration/no_crash_useractions_menu.cpp
@@ -15,8 +15,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <Wrapland/Client/touch.h>
 #include <linux/input.h>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -35,12 +33,12 @@ TEST_CASE("no crash useractions menu", "[win]")
     setup_wayland_connection();
     cursor()->set_pos(QPoint(1280, 512));
 
-    std::unique_ptr<Surface> surface1(create_surface());
-    std::unique_ptr<XdgShellToplevel> shellSurface1(create_xdg_shell_toplevel(surface1));
-    QVERIFY(surface1);
-    QVERIFY(shellSurface1);
+    auto surface = create_surface();
+    auto shellSurface = create_xdg_shell_toplevel(surface);
+    QVERIFY(surface);
+    QVERIFY(shellSurface);
 
-    auto client = render_and_wait_for_shown(surface1, QSize(100, 50), Qt::blue);
+    auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
     QVERIFY(client);
 
     setup.base->mod.space->user_actions_menu->show(QRect(), client);

--- a/tests/integration/no_global_shortcuts.cpp
+++ b/tests/integration/no_global_shortcuts.cpp
@@ -12,8 +12,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <catch2/generators/catch_generators.hpp>
 #include <linux/input.h>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test::no_global_shortcuts
 {
 

--- a/tests/integration/no_global_shortcuts.cpp
+++ b/tests/integration/no_global_shortcuts.cpp
@@ -14,13 +14,16 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 using namespace Wrapland::Client;
 
-static const QString s_serviceName = QStringLiteral("org.kde.KWin.Test.NoGlobalShortcuts");
-static const QString s_path = QStringLiteral("/Test");
-static const QStringList trigger
-    = QStringList{s_serviceName, s_path, s_serviceName, QStringLiteral("shortcut")};
+namespace como::detail::test::no_global_shortcuts
+{
 
 namespace
 {
+
+const QString s_serviceName = QStringLiteral("org.kde.KWin.Test.NoGlobalShortcuts");
+const QString s_path = QStringLiteral("/Test");
+const QStringList trigger
+    = QStringList{s_serviceName, s_path, s_serviceName, QStringLiteral("shortcut")};
 
 class Target : public QObject
 {
@@ -58,9 +61,6 @@ void Target::shortcut()
 }
 
 }
-
-namespace como::detail::test
-{
 
 TEST_CASE("no global shortcuts", "[input]")
 {

--- a/tests/integration/opengl_shadow.cpp
+++ b/tests/integration/opengl_shadow.cpp
@@ -22,7 +22,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 using namespace Wrapland::Client;
 
-namespace como::detail::test
+namespace como::detail::test::opengl_shadow
 {
 
 namespace

--- a/tests/integration/opengl_shadow.cpp
+++ b/tests/integration/opengl_shadow.cpp
@@ -20,8 +20,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <algorithm>
 #include <catch2/generators/catch_generators.hpp>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test::opengl_shadow
 {
 
@@ -545,8 +543,11 @@ TEST_CASE("opengl shadow", "[render]")
         setup_wayland_connection(global_selection::shadow);
 
         // Create a surface.
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
+        QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
+        QVERIFY(shellSurface);
+
         auto* client = render_and_wait_for_shown(surface, QSize(512, 512), Qt::blue);
         QVERIFY(client);
         QVERIFY(!win::decoration(client));
@@ -567,20 +568,18 @@ TEST_CASE("opengl shadow", "[render]")
 
         auto shmPool = get_client().interfaces.shm.get();
 
-        Buffer::Ptr bufferTop
-            = shmPool->createBuffer(referenceShadowTexture.copy(QRect(128, 0, 1, 128)));
+        auto bufferTop = shmPool->createBuffer(referenceShadowTexture.copy(QRect(128, 0, 1, 128)));
         clientShadow->attachTop(bufferTop);
 
-        Buffer::Ptr bufferRight
+        auto bufferRight
             = shmPool->createBuffer(referenceShadowTexture.copy(QRect(128 + 1, 128, 128, 1)));
         clientShadow->attachRight(bufferRight);
 
-        Buffer::Ptr bufferBottom
+        auto bufferBottom
             = shmPool->createBuffer(referenceShadowTexture.copy(QRect(128, 128 + 1, 1, 128)));
         clientShadow->attachBottom(bufferBottom);
 
-        Buffer::Ptr bufferLeft
-            = shmPool->createBuffer(referenceShadowTexture.copy(QRect(0, 128, 128, 1)));
+        auto bufferLeft = shmPool->createBuffer(referenceShadowTexture.copy(QRect(0, 128, 128, 1)));
         clientShadow->attachLeft(bufferLeft);
 
         clientShadow->setOffsets(QMarginsF(128, 128, 128, 128));
@@ -588,7 +587,7 @@ TEST_CASE("opengl shadow", "[render]")
         QSignalSpy commit_spy(client->surface, &Wrapland::Server::Surface::committed);
         QVERIFY(commit_spy.isValid());
         clientShadow->commit();
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
         QVERIFY(commit_spy.wait());
 
         // Check that we got right shadow from the client.
@@ -645,13 +644,15 @@ TEST_CASE("opengl shadow", "[render]")
     SECTION("distribute huge corner tiles")
     {
         // this test verifies that huge corner tiles are distributed correctly
-
         setup_wayland_connection(global_selection::shadow);
 
         // Create a surface.
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
-        auto* client = render_and_wait_for_shown(surface, QSize(64, 64), Qt::blue);
+        auto surface = create_surface();
+        QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
+        QVERIFY(shellSurface);
+
+        auto client = render_and_wait_for_shown(surface, QSize(64, 64), Qt::blue);
         QVERIFY(client);
         QVERIFY(!win::decoration(client));
 
@@ -665,10 +666,10 @@ TEST_CASE("opengl shadow", "[render]")
 
         auto shmPool = get_client().interfaces.shm.get();
 
-        Buffer::Ptr bufferTopLeft = shmPool->createBuffer(referenceTileTexture);
+        auto bufferTopLeft = shmPool->createBuffer(referenceTileTexture);
         clientShadow->attachTopLeft(bufferTopLeft);
 
-        Buffer::Ptr bufferTopRight = shmPool->createBuffer(referenceTileTexture);
+        auto bufferTopRight = shmPool->createBuffer(referenceTileTexture);
         clientShadow->attachTopRight(bufferTopRight);
 
         clientShadow->setOffsets(QMarginsF(256, 256, 256, 0));
@@ -676,7 +677,7 @@ TEST_CASE("opengl shadow", "[render]")
         QSignalSpy commit_spy(client->surface, &Wrapland::Server::Surface::committed);
         QVERIFY(commit_spy.isValid());
         clientShadow->commit();
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
         QVERIFY(commit_spy.wait());
 
         // Check that we got right shadow from the client.

--- a/tests/integration/placement.cpp
+++ b/tests/integration/placement.cpp
@@ -15,8 +15,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <Wrapland/Client/xdgdecoration.h>
 #include <catch2/generators/catch_generators.hpp>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -77,10 +75,10 @@ TEST_CASE("placement", "[win]")
         // create a new window
         rc.surface = create_surface();
         rc.toplevel = create_xdg_shell_toplevel(rc.surface, CreationSetup::CreateOnly);
-        QSignalSpy configSpy(rc.toplevel.get(), &XdgShellToplevel::configured);
+        QSignalSpy configSpy(rc.toplevel.get(), &Wrapland::Client::XdgShellToplevel::configured);
         assert(configSpy.isValid());
 
-        rc.surface->commit(Surface::CommitFlag::None);
+        rc.surface->commit(Wrapland::Client::Surface::CommitFlag::None);
         configSpy.wait();
 
         auto cfgdata = rc.toplevel->get_configure_data();
@@ -152,14 +150,14 @@ TEST_CASE("placement", "[win]")
         setPlacementPolicy(win::placement::maximizing);
 
         // add a top panel
-        std::unique_ptr<Surface> panelSurface(create_surface());
-        std::unique_ptr<QObject> panelShellSurface(create_xdg_shell_toplevel(panelSurface));
+        auto panelSurface = create_surface();
+        auto panelShellSurface = create_xdg_shell_toplevel(panelSurface);
         QVERIFY(panelSurface);
         QVERIFY(panelShellSurface);
 
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface(
+        std::unique_ptr<Wrapland::Client::PlasmaShellSurface> plasmaSurface(
             get_client().interfaces.plasma_shell->createSurface(panelSurface.get()));
-        plasmaSurface->setRole(PlasmaShellSurface::Role::Panel);
+        plasmaSurface->setRole(Wrapland::Client::PlasmaShellSurface::Role::Panel);
         plasmaSurface->setPosition(QPoint(0, 0));
         render_and_wait_for_shown(panelSurface, QSize(1280, 20), Qt::blue);
 
@@ -168,7 +166,8 @@ TEST_CASE("placement", "[win]")
         for (int i = 0; i < 4; i++) {
             placements.push_back(createAndPlaceWindow(QSize(600, 500)));
             auto const& placement = placements.back();
-            QVERIFY(placement.initiallyConfiguredStates & xdg_shell_state::maximized);
+            QVERIFY(placement.initiallyConfiguredStates
+                    & Wrapland::Client::xdg_shell_state::maximized);
             QCOMPARE(placement.initiallyConfiguredSize, QSize(1280, 1024 - 20));
 
             // under the panel
@@ -181,13 +180,14 @@ TEST_CASE("placement", "[win]")
         setPlacementPolicy(win::placement::maximizing);
 
         // add a top panel
-        std::unique_ptr<Surface> panelSurface(create_surface());
-        std::unique_ptr<QObject> panelShellSurface(create_xdg_shell_toplevel(panelSurface));
+        auto panelSurface = create_surface();
+        auto panelShellSurface = create_xdg_shell_toplevel(panelSurface);
         QVERIFY(panelSurface);
         QVERIFY(panelShellSurface);
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface(
+
+        std::unique_ptr<Wrapland::Client::PlasmaShellSurface> plasmaSurface(
             get_client().interfaces.plasma_shell->createSurface(panelSurface.get()));
-        plasmaSurface->setRole(PlasmaShellSurface::Role::Panel);
+        plasmaSurface->setRole(Wrapland::Client::PlasmaShellSurface::Role::Panel);
         plasmaSurface->setPosition(QPoint(0, 0));
         render_and_wait_for_shown(panelSurface, QSize(1280, 20), Qt::blue);
 
@@ -198,8 +198,9 @@ TEST_CASE("placement", "[win]")
             auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
             shellSurface->setFullscreen(true);
 
-            QSignalSpy configSpy(shellSurface.get(), &XdgShellToplevel::configured);
-            surface->commit(Surface::CommitFlag::None);
+            QSignalSpy configSpy(shellSurface.get(),
+                                 &Wrapland::Client::XdgShellToplevel::configured);
+            surface->commit(Wrapland::Client::Surface::CommitFlag::None);
             configSpy.wait();
 
             auto cfgdata = shellSurface->get_configure_data();
@@ -209,7 +210,7 @@ TEST_CASE("placement", "[win]")
 
             auto c = render_and_wait_for_shown(surface, initiallyConfiguredSize, Qt::red);
 
-            QVERIFY(initiallyConfiguredStates & xdg_shell_state::fullscreen);
+            QVERIFY(initiallyConfiguredStates & Wrapland::Client::xdg_shell_state::fullscreen);
             QCOMPARE(initiallyConfiguredSize, QSize(1280, 1024));
             QCOMPARE(c->geo.frame, QRect(0, 0, 1280, 1024));
         }
@@ -224,8 +225,8 @@ TEST_CASE("placement", "[win]")
         group.sync();
         win::space_reconfigure(*setup.base->mod.space);
 
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::red);
         QVERIFY(client);
         QCOMPARE(client->geo.frame, QRect(590, 487, 100, 50));
@@ -246,8 +247,8 @@ TEST_CASE("placement", "[win]")
         cursor()->set_pos(QPoint(200, 300));
         QCOMPARE(cursor()->pos(), QPoint(200, 300));
 
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::red);
         QVERIFY(client);
         QCOMPARE(client->geo.frame, QRect(151, 276, 100, 50));
@@ -265,21 +266,21 @@ TEST_CASE("placement", "[win]")
         group.sync();
         win::space_reconfigure(*setup.base->mod.space);
 
-        std::unique_ptr<Surface> surface1(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface1(create_xdg_shell_toplevel(surface1));
+        auto surface1 = create_surface();
+        auto shellSurface1 = create_xdg_shell_toplevel(surface1);
         auto client1 = render_and_wait_for_shown(surface1, QSize(100, 50), Qt::red);
         QVERIFY(client1);
         QCOMPARE(client1->geo.size(), QSize(100, 50));
 
-        std::unique_ptr<Surface> surface2(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface2(create_xdg_shell_toplevel(surface2));
+        auto surface2 = create_surface();
+        auto shellSurface2 = create_xdg_shell_toplevel(surface2);
         auto client2 = render_and_wait_for_shown(surface2, QSize(100, 50), Qt::blue);
         QVERIFY(client2);
         QVERIFY(client2->geo.pos() != client1->geo.pos());
         QCOMPARE(client2->geo.size(), QSize(100, 50));
 
-        std::unique_ptr<Surface> surface3(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface3(create_xdg_shell_toplevel(surface3));
+        auto surface3 = create_surface();
+        auto shellSurface3 = create_xdg_shell_toplevel(surface3);
         auto client3 = render_and_wait_for_shown(surface3, QSize(100, 50), Qt::green);
         QVERIFY(client3);
         QVERIFY(client3->geo.pos() != client1->geo.pos());

--- a/tests/integration/plasma_surface.cpp
+++ b/tests/integration/plasma_surface.cpp
@@ -15,8 +15,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <Wrapland/Client/surface.h>
 #include <catch2/generators/catch_generators.hpp>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -39,24 +37,25 @@ TEST_CASE("plasma surface", "[win]")
         // this test verifies that a XdgShellClient is set on all subspaces when the role changes
 
         struct data {
-            PlasmaShellSurface::Role role;
+            Wrapland::Client::PlasmaShellSurface::Role role;
             bool expected_on_all_subspaces;
         };
 
-        auto test_data = GENERATE(data{PlasmaShellSurface::Role::Desktop, true},
-                                  data{PlasmaShellSurface::Role::Panel, true},
-                                  data{PlasmaShellSurface::Role::OnScreenDisplay, true},
-                                  data{PlasmaShellSurface::Role::Normal, false},
-                                  data{PlasmaShellSurface::Role::Notification, true},
-                                  data{PlasmaShellSurface::Role::ToolTip, true},
-                                  data{PlasmaShellSurface::Role::CriticalNotification, true},
-                                  data{PlasmaShellSurface::Role::AppletPopup, true});
+        auto test_data
+            = GENERATE(data{Wrapland::Client::PlasmaShellSurface::Role::Desktop, true},
+                       data{Wrapland::Client::PlasmaShellSurface::Role::Panel, true},
+                       data{Wrapland::Client::PlasmaShellSurface::Role::OnScreenDisplay, true},
+                       data{Wrapland::Client::PlasmaShellSurface::Role::Normal, false},
+                       data{Wrapland::Client::PlasmaShellSurface::Role::Notification, true},
+                       data{Wrapland::Client::PlasmaShellSurface::Role::ToolTip, true},
+                       data{Wrapland::Client::PlasmaShellSurface::Role::CriticalNotification, true},
+                       data{Wrapland::Client::PlasmaShellSurface::Role::AppletPopup, true});
 
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface(
+        std::unique_ptr<Wrapland::Client::PlasmaShellSurface> plasmaSurface(
             plasma_shell->createSurface(surface.get()));
         QVERIFY(plasmaSurface);
 
@@ -77,13 +76,13 @@ TEST_CASE("plasma surface", "[win]")
 
         // let's create a second window where we init a little bit different
         // first creating the PlasmaSurface then the Shell Surface
-        std::unique_ptr<Surface> surface2(create_surface());
+        auto surface2 = create_surface();
         QVERIFY(surface2);
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface2(
+        std::unique_ptr<Wrapland::Client::PlasmaShellSurface> plasmaSurface2(
             plasma_shell->createSurface(surface2.get()));
         QVERIFY(plasmaSurface2);
         plasmaSurface2->setRole(test_data.role);
-        std::unique_ptr<XdgShellToplevel> shellSurface2(create_xdg_shell_toplevel(surface2));
+        auto shellSurface2 = create_xdg_shell_toplevel(surface2);
         QVERIFY(shellSurface2);
 
         auto c2 = render_and_wait_for_shown(surface2, QSize(100, 50), Qt::blue);
@@ -98,26 +97,26 @@ TEST_CASE("plasma surface", "[win]")
         // this test verifies that some surface roles don't get focus
 
         struct data {
-            PlasmaShellSurface::Role role;
+            Wrapland::Client::PlasmaShellSurface::Role role;
             bool wants_input;
             bool active;
         };
 
-        auto test_data
-            = GENERATE(data{PlasmaShellSurface::Role::Desktop, true, true},
-                       data{PlasmaShellSurface::Role::Panel, true, false},
-                       data{PlasmaShellSurface::Role::OnScreenDisplay, false, false},
-                       data{PlasmaShellSurface::Role::Normal, true, true},
-                       data{PlasmaShellSurface::Role::Notification, false, false},
-                       data{PlasmaShellSurface::Role::ToolTip, false, false},
-                       data{PlasmaShellSurface::Role::CriticalNotification, false, false},
-                       data{PlasmaShellSurface::Role::AppletPopup, true, true});
+        auto test_data = GENERATE(
+            data{Wrapland::Client::PlasmaShellSurface::Role::Desktop, true, true},
+            data{Wrapland::Client::PlasmaShellSurface::Role::Panel, true, false},
+            data{Wrapland::Client::PlasmaShellSurface::Role::OnScreenDisplay, false, false},
+            data{Wrapland::Client::PlasmaShellSurface::Role::Normal, true, true},
+            data{Wrapland::Client::PlasmaShellSurface::Role::Notification, false, false},
+            data{Wrapland::Client::PlasmaShellSurface::Role::ToolTip, false, false},
+            data{Wrapland::Client::PlasmaShellSurface::Role::CriticalNotification, false, false},
+            data{Wrapland::Client::PlasmaShellSurface::Role::AppletPopup, true, true});
 
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface(
+        std::unique_ptr<Wrapland::Client::PlasmaShellSurface> plasmaSurface(
             plasma_shell->createSurface(surface.get()));
         QVERIFY(plasmaSurface);
         plasmaSurface->setRole(test_data.role);
@@ -132,14 +131,14 @@ TEST_CASE("plasma surface", "[win]")
 
     SECTION("desktop is opaque")
     {
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface(
+        std::unique_ptr<Wrapland::Client::PlasmaShellSurface> plasmaSurface(
             plasma_shell->createSurface(surface.get()));
         QVERIFY(plasmaSurface);
-        plasmaSurface->setRole(PlasmaShellSurface::Role::Desktop);
+        plasmaSurface->setRole(Wrapland::Client::PlasmaShellSurface::Role::Desktop);
 
         // now render to map the window
         auto c = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
@@ -176,16 +175,17 @@ TEST_CASE("plasma surface", "[win]")
                                   data{{1250, 0, 30, 800}, {1080, 0, 200, 300}, {1279, 100}},
                                   data{{1250, 200, 30, 824}, {1080, 0, 200, 300}, {1279, 250}});
 
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface(
+        std::unique_ptr<Wrapland::Client::PlasmaShellSurface> plasmaSurface(
             plasma_shell->createSurface(surface.get()));
         QVERIFY(plasmaSurface);
-        plasmaSurface->setRole(PlasmaShellSurface::Role::Panel);
+        plasmaSurface->setRole(Wrapland::Client::PlasmaShellSurface::Role::Panel);
         plasmaSurface->setPosition(test_data.panel_geo.topLeft());
-        plasmaSurface->setPanelBehavior(PlasmaShellSurface::PanelBehavior::WindowsCanCover);
+        plasmaSurface->setPanelBehavior(
+            Wrapland::Client::PlasmaShellSurface::PanelBehavior::WindowsCanCover);
 
         // now render and map the window
         auto panel = render_and_wait_for_shown(surface, test_data.panel_geo.size(), Qt::blue);
@@ -201,9 +201,9 @@ TEST_CASE("plasma surface", "[win]")
         QCOMPARE(win::get_layer(*panel), win::layer::above);
 
         // create a Window
-        std::unique_ptr<Surface> surface2(create_surface());
+        auto surface2 = create_surface();
         QVERIFY(surface2);
-        std::unique_ptr<XdgShellToplevel> shellSurface2(create_xdg_shell_toplevel(surface2));
+        auto shellSurface2 = create_xdg_shell_toplevel(surface2);
         QVERIFY(shellSurface2);
 
         auto c = render_and_wait_for_shown(surface2, test_data.window_geo.size(), Qt::red);
@@ -235,14 +235,14 @@ TEST_CASE("plasma surface", "[win]")
 
     SECTION("osd placement")
     {
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface(
+        std::unique_ptr<Wrapland::Client::PlasmaShellSurface> plasmaSurface(
             plasma_shell->createSurface(surface.get()));
         QVERIFY(plasmaSurface);
-        plasmaSurface->setRole(PlasmaShellSurface::Role::OnScreenDisplay);
+        plasmaSurface->setRole(Wrapland::Client::PlasmaShellSurface::Role::OnScreenDisplay);
 
         // now render and map the window
         auto c = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
@@ -276,16 +276,16 @@ TEST_CASE("plasma surface", "[win]")
 
     SECTION("osd placement manual position")
     {
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface(
+        std::unique_ptr<Wrapland::Client::PlasmaShellSurface> plasmaSurface(
             plasma_shell->createSurface(surface.get()));
         QVERIFY(plasmaSurface);
 
-        plasmaSurface->setRole(PlasmaShellSurface::Role::OnScreenDisplay);
+        plasmaSurface->setRole(Wrapland::Client::PlasmaShellSurface::Role::OnScreenDisplay);
         plasmaSurface->setPosition(QPoint(50, 70));
 
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
 
         // now render and map the window
@@ -301,37 +301,38 @@ TEST_CASE("plasma surface", "[win]")
     SECTION("panel type has strut")
     {
         struct data {
-            PlasmaShellSurface::PanelBehavior panel_behavior;
+            Wrapland::Client::PlasmaShellSurface::PanelBehavior panel_behavior;
             bool expected_strut;
             QRect expected_max_area;
             win::layer expected_layer;
         };
 
-        auto test_data = GENERATE(data{PlasmaShellSurface::PanelBehavior::AlwaysVisible,
-                                       true,
-                                       {0, 50, 1280, 974},
-                                       win::layer::above},
-                                  data{PlasmaShellSurface::PanelBehavior::AutoHide,
-                                       false,
-                                       {0, 0, 1280, 1024},
-                                       win::layer::above},
-                                  data{PlasmaShellSurface::PanelBehavior::WindowsCanCover,
-                                       false,
-                                       {0, 0, 1280, 1024},
-                                       win::layer::above},
-                                  data{PlasmaShellSurface::PanelBehavior::WindowsGoBelow,
-                                       false,
-                                       {0, 0, 1280, 1024},
-                                       win::layer::above});
+        auto test_data
+            = GENERATE(data{Wrapland::Client::PlasmaShellSurface::PanelBehavior::AlwaysVisible,
+                            true,
+                            {0, 50, 1280, 974},
+                            win::layer::above},
+                       data{Wrapland::Client::PlasmaShellSurface::PanelBehavior::AutoHide,
+                            false,
+                            {0, 0, 1280, 1024},
+                            win::layer::above},
+                       data{Wrapland::Client::PlasmaShellSurface::PanelBehavior::WindowsCanCover,
+                            false,
+                            {0, 0, 1280, 1024},
+                            win::layer::above},
+                       data{Wrapland::Client::PlasmaShellSurface::PanelBehavior::WindowsGoBelow,
+                            false,
+                            {0, 0, 1280, 1024},
+                            win::layer::above});
 
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<QObject> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface(
+        std::unique_ptr<Wrapland::Client::PlasmaShellSurface> plasmaSurface(
             plasma_shell->createSurface(surface.get()));
         QVERIFY(plasmaSurface);
-        plasmaSurface->setRole(PlasmaShellSurface::Role::Panel);
+        plasmaSurface->setRole(Wrapland::Client::PlasmaShellSurface::Role::Panel);
         plasmaSurface->setPosition(QPoint(0, 0));
         plasmaSurface->setPanelBehavior(test_data.panel_behavior);
 
@@ -353,14 +354,14 @@ TEST_CASE("plasma surface", "[win]")
     {
         auto activate = GENERATE(true, false);
 
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface(
+        std::unique_ptr<Wrapland::Client::PlasmaShellSurface> plasmaSurface(
             plasma_shell->createSurface(surface.get()));
         QVERIFY(plasmaSurface);
-        plasmaSurface->setRole(PlasmaShellSurface::Role::Panel);
+        plasmaSurface->setRole(Wrapland::Client::PlasmaShellSurface::Role::Panel);
         plasmaSurface->setPanelTakesFocus(activate);
 
         auto panel = render_and_wait_for_shown(surface, QSize(100, 200), Qt::blue);
@@ -388,12 +389,11 @@ TEST_CASE("plasma surface", "[win]")
 
         auto surface = create_surface();
         QVERIFY(surface);
-
         auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
 
-        auto plasmaSurface
-            = std::unique_ptr<PlasmaShellSurface>(plasma_shell->createSurface(surface.get()));
+        auto plasmaSurface = std::unique_ptr<Wrapland::Client::PlasmaShellSurface>(
+            plasma_shell->createSurface(surface.get()));
         QVERIFY(plasmaSurface);
         plasmaSurface->request_open_under_cursor();
 

--- a/tests/integration/plasma_window.cpp
+++ b/tests/integration/plasma_window.cpp
@@ -16,9 +16,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <Wrapland/Server/seat.h>
 #include <xcb/xcb_icccm.h>
 
-using namespace Wrapland::Client;
-
-namespace como::detail::test
+namespace como::detail::test::plasma_window
 {
 
 namespace
@@ -213,7 +211,7 @@ TEST_CASE("plasma window", "[win]")
         // this test verifies that a PlasmaWindow gets unmapped on Client side when an X11 client is
         // destroyed
         QSignalSpy plasmaWindowCreatedSpy(window_management,
-                                          &PlasmaWindowManagement::windowCreated);
+                                          &Wrapland::Client::PlasmaWindowManagement::windowCreated);
         QVERIFY(plasmaWindowCreatedSpy.isValid());
 
         // create an xcb window
@@ -288,7 +286,8 @@ TEST_CASE("plasma window", "[win]")
         QVERIFY(res_name_spy.wait());
         QCOMPARE(pw->resource_name(), "org.kwinft.wm_class.name2");
 
-        QSignalSpy unmappedSpy(window_management->windows().constFirst(), &PlasmaWindow::unmapped);
+        QSignalSpy unmappedSpy(window_management->windows().constFirst(),
+                               &Wrapland::Client::PlasmaWindow::unmapped);
         QVERIFY(unmappedSpy.isValid());
         QSignalSpy destroyedSpy(window_management->windows().constFirst(), &QObject::destroyed);
         QVERIFY(destroyedSpy.isValid());
@@ -311,7 +310,7 @@ TEST_CASE("plasma window", "[win]")
     {
         // this test verifies that an internal window is not added as a PlasmaWindow to the client
         QSignalSpy plasmaWindowCreatedSpy(window_management,
-                                          &PlasmaWindowManagement::windowCreated);
+                                          &Wrapland::Client::PlasmaWindowManagement::windowCreated);
         QVERIFY(plasmaWindowCreatedSpy.isValid());
         HelperWindow win;
         win.setGeometry(0, 0, 100, 100);
@@ -324,13 +323,12 @@ TEST_CASE("plasma window", "[win]")
     {
         // this test verifies that for a popup window no PlasmaWindow is sent to the client
         QSignalSpy plasmaWindowCreatedSpy(window_management,
-                                          &PlasmaWindowManagement::windowCreated);
+                                          &Wrapland::Client::PlasmaWindowManagement::windowCreated);
         QVERIFY(plasmaWindowCreatedSpy.isValid());
 
         // first create the parent window
-        std::unique_ptr<Surface> parentSurface(create_surface());
-        std::unique_ptr<XdgShellToplevel> parentShellSurface(
-            create_xdg_shell_toplevel(parentSurface));
+        auto parentSurface = create_surface();
+        auto parentShellSurface = create_xdg_shell_toplevel(parentSurface);
         auto parentClient = render_and_wait_for_shown(parentSurface, QSize(100, 50), Qt::blue);
         QVERIFY(parentClient);
         QVERIFY(plasmaWindowCreatedSpy.wait());
@@ -343,9 +341,8 @@ TEST_CASE("plasma window", "[win]")
         pos_data.anchor.edge = Qt::BottomEdge | Qt::RightEdge;
         pos_data.gravity = pos_data.anchor.edge;
 
-        std::unique_ptr<Surface> popupSurface(create_surface());
-        std::unique_ptr<XdgShellPopup> popupShellSurface(
-            create_xdg_shell_popup(popupSurface, parentShellSurface, pos_data));
+        auto popupSurface = create_surface();
+        auto popupShellSurface = create_xdg_shell_popup(popupSurface, parentShellSurface, pos_data);
         auto popupClient = render_and_wait_for_shown(popupSurface, pos_data.size, Qt::blue);
         QVERIFY(popupClient);
         QVERIFY(!plasmaWindowCreatedSpy.wait(100));
@@ -362,7 +359,7 @@ TEST_CASE("plasma window", "[win]")
     {
         // this test verifies that lock screen windows are not exposed to PlasmaWindow
         QSignalSpy plasmaWindowCreatedSpy(window_management,
-                                          &PlasmaWindowManagement::windowCreated);
+                                          &Wrapland::Client::PlasmaWindowManagement::windowCreated);
         QVERIFY(plasmaWindowCreatedSpy.isValid());
 
         // this time we use a QSignalSpy on XdgShellClient as it'a a little bit more complex setup
@@ -415,19 +412,19 @@ TEST_CASE("plasma window", "[win]")
         // this test verifies that also when a ShellSurface gets destroyed without a prior unmap
         // the PlasmaWindow gets destroyed on Client side
         QSignalSpy plasmaWindowCreatedSpy(window_management,
-                                          &PlasmaWindowManagement::windowCreated);
+                                          &Wrapland::Client::PlasmaWindowManagement::windowCreated);
         QVERIFY(plasmaWindowCreatedSpy.isValid());
 
         // first create the parent window
-        std::unique_ptr<Surface> parentSurface(create_surface());
-        std::unique_ptr<XdgShellToplevel> parentShellSurface(
-            create_xdg_shell_toplevel(parentSurface));
+        auto parentSurface = create_surface();
+        auto parentShellSurface = create_xdg_shell_toplevel(parentSurface);
         // map that window
         render(parentSurface, QSize(100, 50), Qt::blue);
         // this should create a plasma window
         QVERIFY(plasmaWindowCreatedSpy.wait());
         QCOMPARE(plasmaWindowCreatedSpy.count(), 1);
-        auto window = plasmaWindowCreatedSpy.first().first().value<PlasmaWindow*>();
+        auto window
+            = plasmaWindowCreatedSpy.first().first().value<Wrapland::Client::PlasmaWindow*>();
         QVERIFY(window);
         QSignalSpy destroyedSpy(window, &QObject::destroyed);
         QVERIFY(destroyedSpy.isValid());

--- a/tests/integration/pointer_input.cpp
+++ b/tests/integration/pointer_input.cpp
@@ -23,7 +23,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <linux/input.h>
 #include <wayland-cursor.h>
 
-namespace como::detail::test
+namespace como::detail::test::pointer_input
 {
 
 namespace
@@ -124,14 +124,14 @@ TEST_CASE("pointer input", "[input]")
     SECTION("warping updates focus")
     {
         // this test verifies that warping the pointer creates pointer enter and leave events
-        using namespace Wrapland::Client;
+
         // create pointer and signal spy for enter and leave signals
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy enteredSpy(pointer, &Pointer::entered);
+        QSignalSpy enteredSpy(pointer, &Wrapland::Client::Pointer::entered);
         QVERIFY(enteredSpy.isValid());
-        QSignalSpy leftSpy(pointer, &Pointer::left);
+        QSignalSpy leftSpy(pointer, &Wrapland::Client::Pointer::left);
         QVERIFY(leftSpy.isValid());
 
         // create a window
@@ -175,14 +175,14 @@ TEST_CASE("pointer input", "[input]")
     SECTION("warping generates pointer moition")
     {
         // this test verifies that warping the pointer creates pointer motion events
-        using namespace Wrapland::Client;
+
         // create pointer and signal spy for enter and motion
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy enteredSpy(pointer, &Pointer::entered);
+        QSignalSpy enteredSpy(pointer, &Wrapland::Client::Pointer::entered);
         QVERIFY(enteredSpy.isValid());
-        QSignalSpy movedSpy(pointer, &Pointer::motion);
+        QSignalSpy movedSpy(pointer, &Wrapland::Client::Pointer::motion);
         QVERIFY(movedSpy.isValid());
 
         // create a window
@@ -214,13 +214,12 @@ TEST_CASE("pointer input", "[input]")
     {
         // this test verifies that pointer motion is handled correctly if
         // the pointer gets warped during processing of input events
-        using namespace Wrapland::Client;
 
         // create pointer
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy movedSpy(pointer, &Pointer::motion);
+        QSignalSpy movedSpy(pointer, &Wrapland::Client::Pointer::motion);
         QVERIFY(movedSpy.isValid());
 
         // warp cursor into expected geometry
@@ -264,7 +263,6 @@ TEST_CASE("pointer input", "[input]")
     {
         // This test verifies that a pointer enter event is generated when the cursor changes to
         // another screen due to removal of screen.
-        using namespace Wrapland::Client;
 
         // Ensure cursor is on second screen.
         cursor()->set_pos(1500, 300);
@@ -273,7 +271,7 @@ TEST_CASE("pointer input", "[input]")
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy enteredSpy(pointer, &Pointer::entered);
+        QSignalSpy enteredSpy(pointer, &Wrapland::Client::Pointer::entered);
         QVERIFY(enteredSpy.isValid());
 
         // Create a window.
@@ -315,9 +313,6 @@ TEST_CASE("pointer input", "[input]")
     SECTION("modifier click unrestricted move")
     {
         // this test ensures that Alt+mouse button press triggers unrestricted move
-
-        using namespace Wrapland::Client;
-
         enum class key {
             meta,
             alt,
@@ -351,7 +346,7 @@ TEST_CASE("pointer input", "[input]")
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy buttonSpy(pointer, &Pointer::buttonStateChanged);
+        QSignalSpy buttonSpy(pointer, &Wrapland::Client::Pointer::buttonStateChanged);
         QVERIFY(buttonSpy.isValid());
 
         // first modify the config for this run
@@ -374,10 +369,12 @@ TEST_CASE("pointer input", "[input]")
         QSignalSpy clientAddedSpy(setup.base->mod.space->qobject.get(),
                                   &space::qobject_t::wayland_window_added);
         QVERIFY(clientAddedSpy.isValid());
+
         auto surface = create_surface();
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
+
         render(surface);
         QVERIFY(clientAddedSpy.wait());
         auto window = get_wayland_window(setup.base->mod.space->stacking.active);
@@ -420,12 +417,12 @@ TEST_CASE("pointer input", "[input]")
     SECTION("modifier click unrestricted move global shortcuts disabled")
     {
         // this test ensures that Alt+mouse button press triggers unrestricted move
-        using namespace Wrapland::Client;
+
         // create pointer and signal spy for button events
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy buttonSpy(pointer, &Pointer::buttonStateChanged);
+        QSignalSpy buttonSpy(pointer, &Wrapland::Client::Pointer::buttonStateChanged);
         QVERIFY(buttonSpy.isValid());
 
         // first modify the config for this run
@@ -452,6 +449,7 @@ TEST_CASE("pointer input", "[input]")
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
+
         render(surface);
         QVERIFY(clientAddedSpy.wait());
         auto window = get_wayland_window(setup.base->mod.space->stacking.active);
@@ -483,9 +481,6 @@ TEST_CASE("pointer input", "[input]")
     {
         // this test verifies that mod+wheel performs a window operation and does not
         // pass the wheel to the window
-
-        using namespace Wrapland::Client;
-
         enum class key {
             meta,
             alt,
@@ -515,7 +510,7 @@ TEST_CASE("pointer input", "[input]")
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy axisSpy(pointer, &Pointer::axisChanged);
+        QSignalSpy axisSpy(pointer, &Wrapland::Client::Pointer::axisChanged);
         QVERIFY(axisSpy.isValid());
 
         // first modify the config for this run
@@ -571,13 +566,12 @@ TEST_CASE("pointer input", "[input]")
     {
         // this test verifies that mod+wheel performs a window operation and does not
         // pass the wheel to the window
-        using namespace Wrapland::Client;
 
         // create pointer and signal spy for button events
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy axisSpy(pointer, &Pointer::axisChanged);
+        QSignalSpy axisSpy(pointer, &Wrapland::Client::Pointer::axisChanged);
         QVERIFY(axisSpy.isValid());
 
         // first modify the config for this run
@@ -627,12 +621,10 @@ TEST_CASE("pointer input", "[input]")
     SECTION("scroll action")
     {
         // this test verifies that scroll on inactive window performs a mouse action
-        using namespace Wrapland::Client;
-
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy axisSpy(pointer, &Pointer::axisChanged);
+        QSignalSpy axisSpy(pointer, &Wrapland::Client::Pointer::axisChanged);
         QVERIFY(axisSpy.isValid());
 
         // first modify the config for this run
@@ -681,8 +673,6 @@ TEST_CASE("pointer input", "[input]")
 
     SECTION("focus follows mouse")
     {
-        using namespace Wrapland::Client;
-
         // need to create a pointer, otherwise it doesn't accept focus
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
@@ -784,8 +774,6 @@ TEST_CASE("pointer input", "[input]")
     {
         // This test performs the mouse button window action on an inactive window it should
         // activate the window and raise it.
-        using namespace Wrapland::Client;
-
         auto button = GENERATE(BTN_LEFT, BTN_MIDDLE, BTN_RIGHT);
 
         // First modify the config for this run - disable FocusFollowsMouse.
@@ -876,8 +864,6 @@ TEST_CASE("pointer input", "[input]")
     {
         // This test verifies the mouse action performed on an active window for all buttons it
         // should trigger a window raise depending on the click raise option.
-        using namespace Wrapland::Client;
-
         auto click_raise = GENERATE(true, false);
         auto button = GENERATE(range(BTN_LEFT, BTN_JOYSTICK));
 
@@ -885,7 +871,7 @@ TEST_CASE("pointer input", "[input]")
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy buttonSpy(pointer, &Pointer::buttonStateChanged);
+        QSignalSpy buttonSpy(pointer, &Wrapland::Client::Pointer::buttonStateChanged);
         QVERIFY(buttonSpy.isValid());
 
         // Adjust config for this run.
@@ -980,13 +966,12 @@ TEST_CASE("pointer input", "[input]")
     {
         // This test verifies that the pointer image gets updated correctly from the client provided
         // data.
-        using namespace Wrapland::Client;
 
         // We need a pointer to get the enter event.
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy enteredSpy(pointer, &Pointer::entered);
+        QSignalSpy enteredSpy(pointer, &Wrapland::Client::Pointer::entered);
         QVERIFY(enteredSpy.isValid());
 
         // Move cursor somewhere the new window won't open.
@@ -1024,7 +1009,8 @@ TEST_CASE("pointer input", "[input]")
         // Create a cursor on the pointer.
         auto cursorSurface = create_surface();
         QVERIFY(cursorSurface);
-        QSignalSpy cursorRenderedSpy(cursorSurface.get(), &Surface::frameRendered);
+        QSignalSpy cursorRenderedSpy(cursorSurface.get(),
+                                     &Wrapland::Client::Surface::frameRendered);
         QVERIFY(cursorRenderedSpy.isValid());
 
         auto red = QImage(QSize(10, 10), QImage::Format_ARGB32_Premultiplied);
@@ -1091,15 +1077,14 @@ TEST_CASE("pointer input", "[input]")
     SECTION("effect override cursor image")
     {
         // This test verifies the effect cursor override handling.
-        using namespace Wrapland::Client;
 
         // We need a pointer to get the enter event and set a cursor.
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy enteredSpy(pointer, &Pointer::entered);
+        QSignalSpy enteredSpy(pointer, &Wrapland::Client::Pointer::entered);
         QVERIFY(enteredSpy.isValid());
-        QSignalSpy leftSpy(pointer, &Pointer::left);
+        QSignalSpy leftSpy(pointer, &Wrapland::Client::Pointer::left);
         QVERIFY(leftSpy.isValid());
 
         // Move cursor somewhere the new window won't open.
@@ -1178,17 +1163,16 @@ TEST_CASE("pointer input", "[input]")
         // a button press outside the window should dismiss the popup
 
         // first create a parent surface
-        using namespace Wrapland::Client;
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy enteredSpy(pointer, &Pointer::entered);
+        QSignalSpy enteredSpy(pointer, &Wrapland::Client::Pointer::entered);
         QVERIFY(enteredSpy.isValid());
-        QSignalSpy leftSpy(pointer, &Pointer::left);
+        QSignalSpy leftSpy(pointer, &Wrapland::Client::Pointer::left);
         QVERIFY(leftSpy.isValid());
-        QSignalSpy buttonStateChangedSpy(pointer, &Pointer::buttonStateChanged);
+        QSignalSpy buttonStateChangedSpy(pointer, &Wrapland::Client::Pointer::buttonStateChanged);
         QVERIFY(buttonStateChangedSpy.isValid());
-        QSignalSpy motionSpy(pointer, &Pointer::motion);
+        QSignalSpy motionSpy(pointer, &Wrapland::Client::Pointer::motion);
         QVERIFY(motionSpy.isValid());
 
         cursor()->set_pos(800, 800);
@@ -1239,7 +1223,8 @@ TEST_CASE("pointer input", "[input]")
         QVERIFY(popupSurface);
         auto popupShellSurface = create_xdg_shell_popup(popupSurface, shellSurface, pos_data);
         QVERIFY(popupShellSurface);
-        QSignalSpy popupDoneSpy(popupShellSurface.get(), &XdgShellPopup::popupDone);
+        QSignalSpy popupDoneSpy(popupShellSurface.get(),
+                                &Wrapland::Client::XdgShellPopup::popupDone);
         QVERIFY(popupDoneSpy.isValid());
         popupShellSurface->requestGrab(seat, 0); // FIXME: Serial.
         render(popupSurface, pos_data.size);
@@ -1302,17 +1287,16 @@ TEST_CASE("pointer input", "[input]")
         // cancels the popup
 
         // first create a parent surface
-        using namespace Wrapland::Client;
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy enteredSpy(pointer, &Pointer::entered);
+        QSignalSpy enteredSpy(pointer, &Wrapland::Client::Pointer::entered);
         QVERIFY(enteredSpy.isValid());
-        QSignalSpy leftSpy(pointer, &Pointer::left);
+        QSignalSpy leftSpy(pointer, &Wrapland::Client::Pointer::left);
         QVERIFY(leftSpy.isValid());
-        QSignalSpy buttonStateChangedSpy(pointer, &Pointer::buttonStateChanged);
+        QSignalSpy buttonStateChangedSpy(pointer, &Wrapland::Client::Pointer::buttonStateChanged);
         QVERIFY(buttonStateChangedSpy.isValid());
-        QSignalSpy motionSpy(pointer, &Pointer::motion);
+        QSignalSpy motionSpy(pointer, &Wrapland::Client::Pointer::motion);
         QVERIFY(motionSpy.isValid());
 
         cursor()->set_pos(800, 800);
@@ -1326,12 +1310,12 @@ TEST_CASE("pointer input", "[input]")
 
         auto deco = get_client().interfaces.xdg_decoration->getToplevelDecoration(
             shellSurface.get(), shellSurface.get());
-        QSignalSpy decoSpy(deco, &XdgDecoration::modeChanged);
+        QSignalSpy decoSpy(deco, &Wrapland::Client::XdgDecoration::modeChanged);
         QVERIFY(decoSpy.isValid());
-        deco->setMode(XdgDecoration::Mode::ServerSide);
-        QCOMPARE(deco->mode(), XdgDecoration::Mode::ClientSide);
+        deco->setMode(Wrapland::Client::XdgDecoration::Mode::ServerSide);
+        QCOMPARE(deco->mode(), Wrapland::Client::XdgDecoration::Mode::ClientSide);
         init_xdg_shell_toplevel(surface, shellSurface);
-        QCOMPARE(deco->mode(), XdgDecoration::Mode::ServerSide);
+        QCOMPARE(deco->mode(), Wrapland::Client::XdgDecoration::Mode::ServerSide);
 
         render(surface);
         QVERIFY(clientAddedSpy.wait());
@@ -1362,7 +1346,8 @@ TEST_CASE("pointer input", "[input]")
         QVERIFY(popupSurface);
         auto popupShellSurface = create_xdg_shell_popup(popupSurface, shellSurface, pos_data);
         QVERIFY(popupShellSurface);
-        QSignalSpy popupDoneSpy(popupShellSurface.get(), &XdgShellPopup::popupDone);
+        QSignalSpy popupDoneSpy(popupShellSurface.get(),
+                                &Wrapland::Client::XdgShellPopup::popupDone);
         QVERIFY(popupDoneSpy.isValid());
         popupShellSurface->requestGrab(seat, 0); // FIXME: Serial.
         render(popupSurface, pos_data.size);
@@ -1397,13 +1382,12 @@ TEST_CASE("pointer input", "[input]")
         // see BUG: 372876
 
         // first create a parent surface
-        using namespace Wrapland::Client;
         auto pointer = seat->createPointer(seat);
         QVERIFY(pointer);
         QVERIFY(pointer->isValid());
-        QSignalSpy enteredSpy(pointer, &Pointer::entered);
+        QSignalSpy enteredSpy(pointer, &Wrapland::Client::Pointer::entered);
         QVERIFY(enteredSpy.isValid());
-        QSignalSpy leftSpy(pointer, &Pointer::left);
+        QSignalSpy leftSpy(pointer, &Wrapland::Client::Pointer::left);
         QVERIFY(leftSpy.isValid());
 
         cursor()->set_pos(800, 800);
@@ -1586,8 +1570,7 @@ TEST_CASE("pointer input", "[input]")
                  win::mouse_cmd::unrestricted_resize);
 
         // create a test client
-        using namespace Wrapland::Client;
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
@@ -1655,8 +1638,7 @@ TEST_CASE("pointer input", "[input]")
                  win::mouse_cmd::unrestricted_move);
 
         // create a test client
-        using namespace Wrapland::Client;
-        std::unique_ptr<Surface> surface(create_surface());
+        auto surface = create_surface();
         QVERIFY(surface);
         auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);

--- a/tests/integration/qpainter_shadow.cpp
+++ b/tests/integration/qpainter_shadow.cpp
@@ -26,8 +26,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <catch2/generators/catch_generators.hpp>
 #include <cmath>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test::qpainter_shadow
 {
 
@@ -496,9 +494,8 @@ TEST_CASE("qpainter shadow", "[render]")
         setup_wayland_connection(global_selection::xdg_decoration);
 
         // Create a decorated client.
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(
-            create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly));
+        auto surface = create_surface();
+        auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         get_client().interfaces.xdg_decoration->getToplevelDecoration(shellSurface.get(),
                                                                       shellSurface.get());
         init_xdg_shell_toplevel(surface, shellSurface);
@@ -556,8 +553,8 @@ TEST_CASE("qpainter shadow", "[render]")
         setup_wayland_connection(global_selection::shadow);
 
         // Create a surface.
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(surface);
         QVERIFY(shellSurface);
 
@@ -588,35 +585,35 @@ TEST_CASE("qpainter shadow", "[render]")
 
         auto shmPool = get_client().interfaces.shm.get();
 
-        Buffer::Ptr bufferTopLeft
+        Wrapland::Client::Buffer::Ptr bufferTopLeft
             = shmPool->createBuffer(referenceShadowTexture.copy(QRect(0, 0, 128, 128)));
         clientShadow->attachTopLeft(bufferTopLeft);
 
-        Buffer::Ptr bufferTop
+        Wrapland::Client::Buffer::Ptr bufferTop
             = shmPool->createBuffer(referenceShadowTexture.copy(QRect(128, 0, 1, 128)));
         clientShadow->attachTop(bufferTop);
 
-        Buffer::Ptr bufferTopRight
+        Wrapland::Client::Buffer::Ptr bufferTopRight
             = shmPool->createBuffer(referenceShadowTexture.copy(QRect(128 + 1, 0, 128, 128)));
         clientShadow->attachTopRight(bufferTopRight);
 
-        Buffer::Ptr bufferRight
+        Wrapland::Client::Buffer::Ptr bufferRight
             = shmPool->createBuffer(referenceShadowTexture.copy(QRect(128 + 1, 128, 128, 1)));
         clientShadow->attachRight(bufferRight);
 
-        Buffer::Ptr bufferBottomRight
+        Wrapland::Client::Buffer::Ptr bufferBottomRight
             = shmPool->createBuffer(referenceShadowTexture.copy(QRect(128 + 1, 128 + 1, 128, 128)));
         clientShadow->attachBottomRight(bufferBottomRight);
 
-        Buffer::Ptr bufferBottom
+        Wrapland::Client::Buffer::Ptr bufferBottom
             = shmPool->createBuffer(referenceShadowTexture.copy(QRect(128, 128 + 1, 1, 128)));
         clientShadow->attachBottom(bufferBottom);
 
-        Buffer::Ptr bufferBottomLeft
+        Wrapland::Client::Buffer::Ptr bufferBottomLeft
             = shmPool->createBuffer(referenceShadowTexture.copy(QRect(0, 128 + 1, 128, 128)));
         clientShadow->attachBottomLeft(bufferBottomLeft);
 
-        Buffer::Ptr bufferLeft
+        Wrapland::Client::Buffer::Ptr bufferLeft
             = shmPool->createBuffer(referenceShadowTexture.copy(QRect(0, 128, 128, 1)));
         clientShadow->attachLeft(bufferLeft);
 
@@ -626,7 +623,7 @@ TEST_CASE("qpainter shadow", "[render]")
         QSignalSpy committed_spy(client->surface, &Wrapland::Server::Surface::committed);
         QVERIFY(committed_spy.isValid());
         clientShadow->commit();
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
         QVERIFY(committed_spy.wait());
         QVERIFY(client->surface->state().updates & Wrapland::Server::surface_change::shadow);
 

--- a/tests/integration/qpainter_shadow.cpp
+++ b/tests/integration/qpainter_shadow.cpp
@@ -28,7 +28,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 
 using namespace Wrapland::Client;
 
-namespace como::detail::test
+namespace como::detail::test::qpainter_shadow
 {
 
 namespace

--- a/tests/integration/quick_tiling.cpp
+++ b/tests/integration/quick_tiling.cpp
@@ -23,7 +23,7 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <linux/input.h>
 #include <xcb/xcb_icccm.h>
 
-namespace como::detail::test
+namespace como::detail::test::quick_tiling
 {
 
 namespace
@@ -77,8 +77,6 @@ TEST_CASE("quick tiling", "[win]")
 
     SECTION("quick tiling")
     {
-        using namespace Wrapland::Client;
-
         struct data {
             win::quicktiles mode;
             QRect expected_geo;
@@ -135,7 +133,8 @@ TEST_CASE("quick tiling", "[win]")
         QCOMPARE(c->geo.frame, QRect(0, 0, 100, 50));
         QCOMPARE(c->control->quicktiling, win::quicktiles::none);
 
-        QSignalSpy configureRequestedSpy(shellSurface.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy(shellSurface.get(),
+                                         &Wrapland::Client::XdgShellToplevel::configured);
         QVERIFY(configureRequestedSpy.isValid());
         QSignalSpy quickTileChangedSpy(c->qobject.get(), &win::window_qobject::quicktiling_changed);
         QVERIFY(quickTileChangedSpy.isValid());
@@ -162,7 +161,9 @@ TEST_CASE("quick tiling", "[win]")
 
         auto cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, test_data.expected_geo.size());
-        REQUIRE(cfgdata.states == (get_client_tiles(test_data.mode) | xdg_shell_state::activated));
+        REQUIRE(
+            cfgdata.states
+            == (get_client_tiles(test_data.mode) | Wrapland::Client::xdg_shell_state::activated));
 
         // attach a new image
         shellSurface->ackConfigure(configureRequestedSpy.back().front().value<quint32>());
@@ -191,8 +192,6 @@ TEST_CASE("quick tiling", "[win]")
 
     SECTION("quick maximizing")
     {
-        using namespace Wrapland::Client;
-
         auto mode = GENERATE(win::quicktiles::maximize, win::quicktiles::none);
 
         auto surface = create_surface();
@@ -209,13 +208,16 @@ TEST_CASE("quick tiling", "[win]")
         QCOMPARE(c->maximizeMode(), win::maximize_mode::restore);
 
         // We have to receive a configure event upon becoming active.
-        QSignalSpy configureRequestedSpy(shellSurface.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy(shellSurface.get(),
+                                         &Wrapland::Client::XdgShellToplevel::configured);
         QVERIFY(configureRequestedSpy.isValid());
         QVERIFY(configureRequestedSpy.wait());
         QCOMPARE(configureRequestedSpy.count(), 1);
 
         auto cfgdata = shellSurface->get_configure_data();
-        REQUIRE(cfgdata.states == xdg_shell_states(xdg_shell_state::activated));
+        REQUIRE(
+            cfgdata.states
+            == Wrapland::Client::xdg_shell_states(Wrapland::Client::xdg_shell_state::activated));
 
         QSignalSpy quickTileChangedSpy(c->qobject.get(), &win::window_qobject::quicktiling_changed);
         QVERIFY(quickTileChangedSpy.isValid());
@@ -242,9 +244,10 @@ TEST_CASE("quick tiling", "[win]")
 
         cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(1280, 1024));
-        REQUIRE(cfgdata.states
-                == xdg_shell_states(get_client_tiles(win::quicktiles::maximize)
-                                    | xdg_shell_state::activated));
+        REQUIRE(
+            cfgdata.states
+            == Wrapland::Client::xdg_shell_states(get_client_tiles(win::quicktiles::maximize)
+                                                  | Wrapland::Client::xdg_shell_state::activated));
 
         // Attach a new image.
         shellSurface->ackConfigure(configureRequestedSpy.back().front().value<quint32>());
@@ -274,7 +277,9 @@ TEST_CASE("quick tiling", "[win]")
 
         cfgdata = shellSurface->get_configure_data();
         REQUIRE(cfgdata.size == QSize(100, 50));
-        REQUIRE(cfgdata.states == xdg_shell_states(xdg_shell_state::activated));
+        REQUIRE(
+            cfgdata.states
+            == Wrapland::Client::xdg_shell_states(Wrapland::Client::xdg_shell_state::activated));
 
         // render again
         shellSurface->ackConfigure(configureRequestedSpy.back().front().value<quint32>());
@@ -289,8 +294,6 @@ TEST_CASE("quick tiling", "[win]")
 
     SECTION("keyboard move")
     {
-        using namespace Wrapland::Client;
-
         struct data {
             QPoint target;
             win::quicktiles expected_mode;
@@ -356,8 +359,6 @@ TEST_CASE("quick tiling", "[win]")
 
     SECTION("pointer move")
     {
-        using namespace Wrapland::Client;
-
         struct data {
             QPoint target;
             win::quicktiles expected_mode;
@@ -378,9 +379,10 @@ TEST_CASE("quick tiling", "[win]")
         QVERIFY(shellSurface);
 
         // wait for the initial configure event
-        QSignalSpy configureRequestedSpy(shellSurface.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy(shellSurface.get(),
+                                         &Wrapland::Client::XdgShellToplevel::configured);
         QVERIFY(configureRequestedSpy.isValid());
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
         QVERIFY(configureRequestedSpy.wait());
         QCOMPARE(configureRequestedSpy.count(), 1);
 
@@ -425,8 +427,6 @@ TEST_CASE("quick tiling", "[win]")
     {
         // test verifies that touch on decoration also allows quick tiling
         // see BUG: 390113
-        using namespace Wrapland::Client;
-
         struct data {
             QPoint target;
             win::quicktiles expected_mode;
@@ -448,17 +448,18 @@ TEST_CASE("quick tiling", "[win]")
 
         auto deco = get_client().interfaces.xdg_decoration->getToplevelDecoration(
             shellSurface.get(), shellSurface.get());
-        QSignalSpy decoSpy(deco, &XdgDecoration::modeChanged);
+        QSignalSpy decoSpy(deco, &Wrapland::Client::XdgDecoration::modeChanged);
         QVERIFY(decoSpy.isValid());
 
-        deco->setMode(XdgDecoration::Mode::ServerSide);
-        QCOMPARE(deco->mode(), XdgDecoration::Mode::ClientSide);
+        deco->setMode(Wrapland::Client::XdgDecoration::Mode::ServerSide);
+        QCOMPARE(deco->mode(), Wrapland::Client::XdgDecoration::Mode::ClientSide);
 
-        QSignalSpy configureRequestedSpy(shellSurface.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy(shellSurface.get(),
+                                         &Wrapland::Client::XdgShellToplevel::configured);
         QVERIFY(configureRequestedSpy.isValid());
 
         init_xdg_shell_toplevel(surface, shellSurface);
-        QCOMPARE(deco->mode(), XdgDecoration::Mode::ServerSide);
+        QCOMPARE(deco->mode(), Wrapland::Client::XdgDecoration::Mode::ServerSide);
         QCOMPARE(configureRequestedSpy.count(), 1);
         QVERIFY(configureRequestedSpy.last().first().toSize().isEmpty());
 
@@ -700,8 +701,6 @@ TEST_CASE("quick tiling", "[win]")
 
     SECTION("shortcut")
     {
-        using namespace Wrapland::Client;
-
         struct data {
             std::vector<std::string> shortcuts;
             win::quicktiles expected_mode;
@@ -751,7 +750,8 @@ TEST_CASE("quick tiling", "[win]")
         QCOMPARE(c->control->quicktiling, win::quicktiles::none);
 
         // We have to receive a configure event when the client becomes active.
-        QSignalSpy configureRequestedSpy(shellSurface.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy(shellSurface.get(),
+                                         &Wrapland::Client::XdgShellToplevel::configured);
         QVERIFY(configureRequestedSpy.isValid());
         QVERIFY(configureRequestedSpy.wait());
         QCOMPARE(configureRequestedSpy.count(), 1);
@@ -803,8 +803,6 @@ TEST_CASE("quick tiling", "[win]")
 
     SECTION("script")
     {
-        using namespace Wrapland::Client;
-
         struct data {
             std::string action;
             win::quicktiles expected_mode;
@@ -836,7 +834,8 @@ TEST_CASE("quick tiling", "[win]")
         QCOMPARE(c->control->quicktiling, win::quicktiles::none);
 
         // We have to receive a configure event upon the client becoming active.
-        QSignalSpy configureRequestedSpy(shellSurface.get(), &XdgShellToplevel::configured);
+        QSignalSpy configureRequestedSpy(shellSurface.get(),
+                                         &Wrapland::Client::XdgShellToplevel::configured);
         QVERIFY(configureRequestedSpy.isValid());
         QVERIFY(configureRequestedSpy.wait());
         QCOMPARE(configureRequestedSpy.count(), 1);

--- a/tests/integration/screen_changes.cpp
+++ b/tests/integration/screen_changes.cpp
@@ -11,8 +11,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <Wrapland/Client/xdgoutput.h>
 #include <catch2/generators/catch_generators.hpp>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -32,18 +30,19 @@ TEST_CASE("screen changes", "[base]")
     cursor()->set_pos(QPoint(640, 512));
 
     // first create a registry to get signals about Outputs announced/removed
-    Registry registry;
-    QSignalSpy allAnnounced(&registry, &Registry::interfacesAnnounced);
+    Wrapland::Client::Registry registry;
+    QSignalSpy allAnnounced(&registry, &Wrapland::Client::Registry::interfacesAnnounced);
     QVERIFY(allAnnounced.isValid());
-    QSignalSpy outputAnnouncedSpy(&registry, &Registry::outputAnnounced);
+    QSignalSpy outputAnnouncedSpy(&registry, &Wrapland::Client::Registry::outputAnnounced);
     QVERIFY(outputAnnouncedSpy.isValid());
-    QSignalSpy outputRemovedSpy(&registry, &Registry::outputRemoved);
+    QSignalSpy outputRemovedSpy(&registry, &Wrapland::Client::Registry::outputRemoved);
     QVERIFY(outputRemovedSpy.isValid());
     registry.create(get_client().connection);
     QVERIFY(registry.isValid());
     registry.setup();
     QVERIFY(allAnnounced.wait());
-    const auto xdgOMData = registry.interface(Registry::Interface::XdgOutputUnstableV1);
+    const auto xdgOMData
+        = registry.interface(Wrapland::Client::Registry::Interface::XdgOutputUnstableV1);
     auto xdgOutputManager = registry.createXdgOutputManager(xdgOMData.name, xdgOMData.version);
 
     // should be one output
@@ -77,32 +76,32 @@ TEST_CASE("screen changes", "[base]")
     QCOMPARE(outputRemovedSpy.count(), 1);
 
     // let's create the output objects to ensure they are correct
-    std::unique_ptr<Output> o1(
+    std::unique_ptr<Wrapland::Client::Output> o1(
         registry.createOutput(outputAnnouncedSpy.first().first().value<quint32>(),
                               outputAnnouncedSpy.first().last().value<quint32>()));
     QVERIFY(o1->isValid());
-    QSignalSpy o1ChangedSpy(o1.get(), &Output::changed);
+    QSignalSpy o1ChangedSpy(o1.get(), &Wrapland::Client::Output::changed);
     QVERIFY(o1ChangedSpy.isValid());
     QVERIFY(o1ChangedSpy.wait());
     QCOMPARE(o1->geometry(), geometries.at(0));
-    std::unique_ptr<Output> o2(
+    std::unique_ptr<Wrapland::Client::Output> o2(
         registry.createOutput(outputAnnouncedSpy.last().first().value<quint32>(),
                               outputAnnouncedSpy.last().last().value<quint32>()));
     QVERIFY(o2->isValid());
-    QSignalSpy o2ChangedSpy(o2.get(), &Output::changed);
+    QSignalSpy o2ChangedSpy(o2.get(), &Wrapland::Client::Output::changed);
     QVERIFY(o2ChangedSpy.isValid());
     QVERIFY(o2ChangedSpy.wait());
     QCOMPARE(o2->geometry(), geometries.at(1));
 
     // and check XDGOutput is synced
-    std::unique_ptr<XdgOutput> xdgO1(xdgOutputManager->getXdgOutput(o1.get()));
-    QSignalSpy xdgO1ChangedSpy(xdgO1.get(), &XdgOutput::changed);
+    std::unique_ptr<Wrapland::Client::XdgOutput> xdgO1(xdgOutputManager->getXdgOutput(o1.get()));
+    QSignalSpy xdgO1ChangedSpy(xdgO1.get(), &Wrapland::Client::XdgOutput::changed);
     QVERIFY(xdgO1ChangedSpy.isValid());
     QVERIFY(xdgO1ChangedSpy.wait());
     QCOMPARE(xdgO1->logicalPosition(), geometries.at(0).topLeft());
     QCOMPARE(xdgO1->logicalSize(), geometries.at(0).size());
-    std::unique_ptr<XdgOutput> xdgO2(xdgOutputManager->getXdgOutput(o2.get()));
-    QSignalSpy xdgO2ChangedSpy(xdgO2.get(), &XdgOutput::changed);
+    std::unique_ptr<Wrapland::Client::XdgOutput> xdgO2(xdgOutputManager->getXdgOutput(o2.get()));
+    QSignalSpy xdgO2ChangedSpy(xdgO2.get(), &Wrapland::Client::XdgOutput::changed);
     QVERIFY(xdgO2ChangedSpy.isValid());
     QVERIFY(xdgO2ChangedSpy.wait());
     QCOMPARE(xdgO2->logicalPosition(), geometries.at(1).topLeft());
@@ -113,9 +112,9 @@ TEST_CASE("screen changes", "[base]")
     outputRemovedSpy.clear();
     outputs_changed_spy.clear();
 
-    QSignalSpy o1RemovedSpy(o1.get(), &Output::removed);
+    QSignalSpy o1RemovedSpy(o1.get(), &Wrapland::Client::Output::removed);
     QVERIFY(o1RemovedSpy.isValid());
-    QSignalSpy o2RemovedSpy(o2.get(), &Output::removed);
+    QSignalSpy o2RemovedSpy(o2.get(), &Wrapland::Client::Output::removed);
     QVERIFY(o2RemovedSpy.isValid());
 
     auto const geometries2 = std::vector<QRect>{{0, 0, 1280, 1024}};

--- a/tests/integration/scripting/minimize_all.cpp
+++ b/tests/integration/scripting/minimize_all.cpp
@@ -45,8 +45,6 @@ TEST_CASE("minimize all", "[script]")
 {
     // This test verifies that all windows are minimized when Meta+Shift+D
     // is pressed, and unminimized when the shortcut is pressed once again.
-    using namespace Wrapland::Client;
-
     qputenv("XDG_DATA_DIRS", QCoreApplication::applicationDirPath().toUtf8());
 
 #if USE_XWL
@@ -72,15 +70,21 @@ TEST_CASE("minimize all", "[script]")
     QTRY_COMPARE(runningChangedSpy.count(), 1);
 
     // Create a couple of test clients.
-    std::unique_ptr<Surface> surface1(create_surface());
-    std::unique_ptr<XdgShellToplevel> shellSurface1(create_xdg_shell_toplevel(surface1));
+    auto surface1 = create_surface();
+    QVERIFY(surface1);
+    auto shellSurface1 = create_xdg_shell_toplevel(surface1);
+    QVERIFY(shellSurface1);
+
     auto client1 = render_and_wait_for_shown(surface1, QSize(100, 50), Qt::blue);
     QVERIFY(client1);
     QVERIFY(client1->control->active);
     QVERIFY(client1->isMinimizable());
 
-    std::unique_ptr<Surface> surface2(create_surface());
-    std::unique_ptr<XdgShellToplevel> shellSurface2(create_xdg_shell_toplevel(surface2));
+    auto surface2 = create_surface();
+    QVERIFY(surface2);
+    auto shellSurface2 = create_xdg_shell_toplevel(surface2);
+    QVERIFY(shellSurface2);
+
     auto client2 = render_and_wait_for_shown(surface2, QSize(100, 50), Qt::red);
     QVERIFY(client2);
     QVERIFY(client2->control->active);

--- a/tests/integration/showing_desktop.cpp
+++ b/tests/integration/showing_desktop.cpp
@@ -10,8 +10,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <Wrapland/Client/surface.h>
 #include <catch2/generators/catch_generators.hpp>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -29,14 +27,15 @@ TEST_CASE("showing desktop", "[win]")
 
     SECTION("restore focus")
     {
-        std::unique_ptr<Surface> surface1(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface1(create_xdg_shell_toplevel(surface1));
+        auto surface1 = create_surface();
+        auto shellSurface1 = create_xdg_shell_toplevel(surface1);
         QVERIFY(surface1);
         QVERIFY(shellSurface1);
 
         auto client1 = render_and_wait_for_shown(surface1, QSize(100, 50), Qt::blue);
-        std::unique_ptr<Surface> surface2(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface2(create_xdg_shell_toplevel(surface2));
+
+        auto surface2 = create_surface();
+        auto shellSurface2 = create_xdg_shell_toplevel(surface2);
         QVERIFY(surface2);
         QVERIFY(shellSurface2);
 
@@ -57,29 +56,28 @@ TEST_CASE("showing desktop", "[win]")
     {
         // first create a desktop window
 
-        std::unique_ptr<Surface> desktopSurface(create_surface());
+        auto desktopSurface = create_surface();
         QVERIFY(desktopSurface);
-        std::unique_ptr<XdgShellToplevel> desktopShellSurface(
-            create_xdg_shell_toplevel(desktopSurface));
+        auto desktopShellSurface = create_xdg_shell_toplevel(desktopSurface);
         QVERIFY(desktopShellSurface);
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface(
+        std::unique_ptr<Wrapland::Client::PlasmaShellSurface> plasmaSurface(
             get_client().interfaces.plasma_shell->createSurface(desktopSurface.get()));
         QVERIFY(plasmaSurface);
-        plasmaSurface->setRole(PlasmaShellSurface::Role::Desktop);
+        plasmaSurface->setRole(Wrapland::Client::PlasmaShellSurface::Role::Desktop);
 
         auto desktop = render_and_wait_for_shown(desktopSurface, QSize(100, 50), Qt::blue);
         QVERIFY(desktop);
         QVERIFY(win::is_desktop(desktop));
 
         // now create some windows
-        std::unique_ptr<Surface> surface1(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface1(create_xdg_shell_toplevel(surface1));
+        auto surface1 = create_surface();
+        auto shellSurface1 = create_xdg_shell_toplevel(surface1);
         QVERIFY(surface1);
         QVERIFY(shellSurface1);
 
         auto client1 = render_and_wait_for_shown(surface1, QSize(100, 50), Qt::blue);
-        std::unique_ptr<Surface> surface2(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface2(create_xdg_shell_toplevel(surface2));
+        auto surface2 = create_surface();
+        auto shellSurface2 = create_xdg_shell_toplevel(surface2);
         QVERIFY(surface2);
         QVERIFY(shellSurface2);
 

--- a/tests/integration/struts.cpp
+++ b/tests/integration/struts.cpp
@@ -140,8 +140,6 @@ TEST_CASE("struts", "[win]")
                  QRegion(0, 10, 32, 390).united(QRegion(0, 450, 40, 100))});
 
         // this test verifies that struts on Wayland panels are handled correctly
-        using namespace Wrapland::Client;
-
         auto const& outputs = setup.base->outputs;
         REQUIRE(win::space_window_area(
                     *setup.base->mod.space, win::area_option::placement, outputs.at(0), 1)
@@ -207,7 +205,7 @@ TEST_CASE("struts", "[win]")
             auto plasmaSurface = std::unique_ptr<Wrapland::Client::PlasmaShellSurface>(
                 plasma_shell->createSurface(surface.get()));
             plasmaSurface->setPosition(window_geo.topLeft());
-            plasmaSurface->setRole(PlasmaShellSurface::Role::Panel);
+            plasmaSurface->setRole(Wrapland::Client::PlasmaShellSurface::Role::Panel);
             init_xdg_shell_toplevel(surface, shellSurface);
 
             // map the window
@@ -289,14 +287,14 @@ TEST_CASE("struts", "[win]")
     SECTION("move wayland panel")
     {
         // this test verifies that repositioning a Wayland panel updates the client area
-        using namespace Wrapland::Client;
         const QRect windowGeometry(0, 1000, 1280, 24);
         auto surface = create_surface();
         auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface(
+
+        auto plasmaSurface = std::unique_ptr<Wrapland::Client::PlasmaShellSurface>(
             plasma_shell->createSurface(surface.get()));
         plasmaSurface->setPosition(windowGeometry.topLeft());
-        plasmaSurface->setRole(PlasmaShellSurface::Role::Panel);
+        plasmaSurface->setRole(Wrapland::Client::PlasmaShellSurface::Role::Panel);
         init_xdg_shell_toplevel(surface, shellSurface);
 
         // map the window
@@ -350,8 +348,6 @@ TEST_CASE("struts", "[win]")
 
     SECTION("wayland mobile panel")
     {
-        using namespace Wrapland::Client;
-
         // First enable maxmizing policy
         auto group = setup.base->config.main->group(QStringLiteral("Windows"));
         group.writeEntry("Placement", "maximizing");
@@ -360,17 +356,18 @@ TEST_CASE("struts", "[win]")
 
         // create first top panel
         const QRect windowGeometry(0, 0, 1280, 60);
-        auto surface = create_surface();
-        auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface(
-            plasma_shell->createSurface(surface.get()));
+        auto surface1 = create_surface();
+        auto shellSurface1 = create_xdg_shell_toplevel(surface1, CreationSetup::CreateOnly);
+
+        auto plasmaSurface = std::unique_ptr<Wrapland::Client::PlasmaShellSurface>(
+            plasma_shell->createSurface(surface1.get()));
         plasmaSurface->setPosition(windowGeometry.topLeft());
-        plasmaSurface->setRole(PlasmaShellSurface::Role::Panel);
-        init_xdg_shell_toplevel(surface, shellSurface);
+        plasmaSurface->setRole(Wrapland::Client::PlasmaShellSurface::Role::Panel);
+        init_xdg_shell_toplevel(surface1, shellSurface1);
 
         // map the first panel
         auto c = render_and_wait_for_shown(
-            surface, windowGeometry.size(), Qt::red, QImage::Format_RGB32);
+            surface1, windowGeometry.size(), Qt::red, QImage::Format_RGB32);
         QVERIFY(c);
         QVERIFY(!c->control->active);
         REQUIRE(c->geo.frame == windowGeometry);
@@ -396,13 +393,13 @@ TEST_CASE("struts", "[win]")
 
         // create another bottom panel
         const QRect windowGeometry2(0, 874, 1280, 150);
-        std::unique_ptr<Surface> surface2(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface2(
-            create_xdg_shell_toplevel(surface2, CreationSetup::CreateOnly));
-        std::unique_ptr<PlasmaShellSurface> plasmaSurface2(
+        auto surface2 = create_surface();
+        auto shellSurface2 = create_xdg_shell_toplevel(surface2, CreationSetup::CreateOnly);
+
+        auto plasmaSurface2 = std::unique_ptr<Wrapland::Client::PlasmaShellSurface>(
             plasma_shell->createSurface(surface2.get()));
         plasmaSurface2->setPosition(windowGeometry2.topLeft());
-        plasmaSurface2->setRole(PlasmaShellSurface::Role::Panel);
+        plasmaSurface2->setRole(Wrapland::Client::PlasmaShellSurface::Role::Panel);
         init_xdg_shell_toplevel(surface2, shellSurface2);
 
         auto c1 = render_and_wait_for_shown(
@@ -431,7 +428,7 @@ TEST_CASE("struts", "[win]")
                  QRect(0, 60, 2560, 814));
 
         // Destroy test clients.
-        shellSurface.reset();
+        shellSurface1.reset();
         QVERIFY(wait_for_destroyed(c));
         shellSurface2.reset();
         QVERIFY(wait_for_destroyed(c1));

--- a/tests/integration/subspace.cpp
+++ b/tests/integration/subspace.cpp
@@ -9,8 +9,6 @@
 #include <Wrapland/Client/surface.h>
 #include <catch2/generators/catch_generators.hpp>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -846,9 +844,9 @@ TEST_CASE("subspace", "[win]")
         QCOMPARE(win::subspaces_get_current_x11id(*vd_manager), 2u);
 
         // now create a window on this subspace
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
         QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
 
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
@@ -881,9 +879,9 @@ TEST_CASE("subspace", "[win]")
         QCOMPARE(win::subspaces_get_current_x11id(*vd_manager), 3u);
 
         // now create a window on this subspace
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
         QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
 
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
@@ -965,9 +963,9 @@ TEST_CASE("subspace", "[win]")
         QCOMPARE(win::subspaces_get_current_x11id(*vd_manager), 3u);
 
         // now create a window on this subspace
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
         QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
         QVERIFY(shellSurface);
 
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);

--- a/tests/integration/tabbox.cpp
+++ b/tests/integration/tabbox.cpp
@@ -11,8 +11,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <catch2/generators/catch_generators.hpp>
 #include <linux/input.h>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -41,25 +39,27 @@ TEST_CASE("tabbox", "[win]")
         // this test verifies that Alt+tab works correctly moving forward
 
         // first create three windows
-        std::unique_ptr<Surface> surface1(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface1(create_xdg_shell_toplevel(surface1));
+        auto surface1 = create_surface();
         QVERIFY(surface1);
+        auto shellSurface1 = create_xdg_shell_toplevel(surface1);
         QVERIFY(shellSurface1);
 
         auto c1 = render_and_wait_for_shown(surface1, QSize(100, 50), Qt::blue);
         QVERIFY(c1);
         QVERIFY(c1->control->active);
-        std::unique_ptr<Surface> surface2(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface2(create_xdg_shell_toplevel(surface2));
+
+        auto surface2 = create_surface();
         QVERIFY(surface2);
+        auto shellSurface2 = create_xdg_shell_toplevel(surface2);
         QVERIFY(shellSurface2);
 
         auto c2 = render_and_wait_for_shown(surface2, QSize(100, 50), Qt::red);
         QVERIFY(c2);
         QVERIFY(c2->control->active);
-        std::unique_ptr<Surface> surface3(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface3(create_xdg_shell_toplevel(surface3));
+
+        auto surface3 = create_surface();
         QVERIFY(surface3);
+        auto shellSurface3 = create_xdg_shell_toplevel(surface3);
         QVERIFY(shellSurface3);
 
         auto c3 = render_and_wait_for_shown(surface3, QSize(100, 50), Qt::red);
@@ -104,25 +104,27 @@ TEST_CASE("tabbox", "[win]")
         // this test verifies that Alt+Shift+tab works correctly moving backward
 
         // first create three windows
-        std::unique_ptr<Surface> surface1(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface1(create_xdg_shell_toplevel(surface1));
+        auto surface1 = create_surface();
         QVERIFY(surface1);
+        auto shellSurface1 = create_xdg_shell_toplevel(surface1);
         QVERIFY(shellSurface1);
 
         auto c1 = render_and_wait_for_shown(surface1, QSize(100, 50), Qt::blue);
         QVERIFY(c1);
         QVERIFY(c1->control->active);
-        std::unique_ptr<Surface> surface2(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface2(create_xdg_shell_toplevel(surface2));
+
+        auto surface2 = create_surface();
         QVERIFY(surface2);
+        auto shellSurface2 = create_xdg_shell_toplevel(surface2);
         QVERIFY(shellSurface2);
 
         auto c2 = render_and_wait_for_shown(surface2, QSize(100, 50), Qt::red);
         QVERIFY(c2);
         QVERIFY(c2->control->active);
-        std::unique_ptr<Surface> surface3(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface3(create_xdg_shell_toplevel(surface3));
+
+        auto surface3 = create_surface();
         QVERIFY(surface3);
+        auto shellSurface3 = create_xdg_shell_toplevel(surface3);
         QVERIFY(shellSurface3);
 
         auto c3 = render_and_wait_for_shown(surface3, QSize(100, 50), Qt::red);
@@ -173,25 +175,27 @@ TEST_CASE("tabbox", "[win]")
         // bug 368590
 
         // first create three windows
-        std::unique_ptr<Surface> surface1(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface1(create_xdg_shell_toplevel(surface1));
+        auto surface1 = create_surface();
         QVERIFY(surface1);
+        auto shellSurface1 = create_xdg_shell_toplevel(surface1);
         QVERIFY(shellSurface1);
 
         auto c1 = render_and_wait_for_shown(surface1, QSize(100, 50), Qt::blue);
         QVERIFY(c1);
         QVERIFY(c1->control->active);
-        std::unique_ptr<Surface> surface2(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface2(create_xdg_shell_toplevel(surface2));
+
+        auto surface2 = create_surface();
         QVERIFY(surface2);
+        auto shellSurface2 = create_xdg_shell_toplevel(surface2);
         QVERIFY(shellSurface2);
 
         auto c2 = render_and_wait_for_shown(surface2, QSize(100, 50), Qt::red);
         QVERIFY(c2);
         QVERIFY(c2->control->active);
-        std::unique_ptr<Surface> surface3(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface3(create_xdg_shell_toplevel(surface3));
+
+        auto surface3 = create_surface();
         QVERIFY(surface3);
+        auto shellSurface3 = create_xdg_shell_toplevel(surface3);
         QVERIFY(shellSurface3);
 
         auto c3 = render_and_wait_for_shown(surface3, QSize(100, 50), Qt::red);

--- a/tests/integration/touch_input.cpp
+++ b/tests/integration/touch_input.cpp
@@ -44,8 +44,6 @@ TEST_CASE("touch input", "[input]")
     std::vector<window_holder> clients;
 
     auto showWindow = [&](bool decorated = false) -> wayland_window* {
-        using namespace Wrapland::Client;
-
         window_holder client;
         client.surface = create_surface();
         REQUIRE(client.surface.get());
@@ -55,12 +53,12 @@ TEST_CASE("touch input", "[input]")
         if (decorated) {
             auto deco = get_client().interfaces.xdg_decoration->getToplevelDecoration(
                 client.toplevel.get(), client.toplevel.get());
-            QSignalSpy decoSpy(deco, &XdgDecoration::modeChanged);
+            QSignalSpy decoSpy(deco, &Wrapland::Client::XdgDecoration::modeChanged);
             REQUIRE(decoSpy.isValid());
-            deco->setMode(XdgDecoration::Mode::ServerSide);
-            REQUIRE(deco->mode() == XdgDecoration::Mode::ClientSide);
+            deco->setMode(Wrapland::Client::XdgDecoration::Mode::ServerSide);
+            REQUIRE(deco->mode() == Wrapland::Client::XdgDecoration::Mode::ClientSide);
             init_xdg_shell_toplevel(client.surface, client.toplevel);
-            REQUIRE(deco->mode() == XdgDecoration::Mode::ServerSide);
+            REQUIRE(deco->mode() == Wrapland::Client::XdgDecoration::Mode::ServerSide);
         } else {
             init_xdg_shell_toplevel(client.surface, client.toplevel);
         }
@@ -101,23 +99,21 @@ TEST_CASE("touch input", "[input]")
 
     SECTION("multiple touch points")
     {
-        using namespace Wrapland::Client;
-
         auto decorated = GENERATE(false, true);
 
         auto c = showWindow(decorated);
         REQUIRE((win::decoration(c) != nullptr) == decorated);
         win::move(c, QPoint(100, 100));
         QVERIFY(c);
-        QSignalSpy sequenceStartedSpy(touch.get(), &Touch::sequenceStarted);
+        QSignalSpy sequenceStartedSpy(touch.get(), &Wrapland::Client::Touch::sequenceStarted);
         QVERIFY(sequenceStartedSpy.isValid());
-        QSignalSpy pointAddedSpy(touch.get(), &Touch::pointAdded);
+        QSignalSpy pointAddedSpy(touch.get(), &Wrapland::Client::Touch::pointAdded);
         QVERIFY(pointAddedSpy.isValid());
-        QSignalSpy pointMovedSpy(touch.get(), &Touch::pointMoved);
+        QSignalSpy pointMovedSpy(touch.get(), &Wrapland::Client::Touch::pointMoved);
         QVERIFY(pointMovedSpy.isValid());
-        QSignalSpy pointRemovedSpy(touch.get(), &Touch::pointRemoved);
+        QSignalSpy pointRemovedSpy(touch.get(), &Wrapland::Client::Touch::pointRemoved);
         QVERIFY(pointRemovedSpy.isValid());
-        QSignalSpy endedSpy(touch.get(), &Touch::sequenceEnded);
+        QSignalSpy endedSpy(touch.get(), &Wrapland::Client::Touch::sequenceEnded);
         QVERIFY(endedSpy.isValid());
 
         quint32 timestamp = 1;
@@ -165,16 +161,14 @@ TEST_CASE("touch input", "[input]")
 
     SECTION("cancel")
     {
-        using namespace Wrapland::Client;
-
         auto c = showWindow();
         win::move(c, QPoint(100, 100));
         QVERIFY(c);
-        QSignalSpy sequenceStartedSpy(touch.get(), &Touch::sequenceStarted);
+        QSignalSpy sequenceStartedSpy(touch.get(), &Wrapland::Client::Touch::sequenceStarted);
         QVERIFY(sequenceStartedSpy.isValid());
-        QSignalSpy cancelSpy(touch.get(), &Touch::sequenceCanceled);
+        QSignalSpy cancelSpy(touch.get(), &Wrapland::Client::Touch::sequenceCanceled);
         QVERIFY(cancelSpy.isValid());
-        QSignalSpy pointRemovedSpy(touch.get(), &Touch::pointRemoved);
+        QSignalSpy pointRemovedSpy(touch.get(), &Wrapland::Client::Touch::pointRemoved);
         QVERIFY(pointRemovedSpy.isValid());
 
         quint32 timestamp = 1;
@@ -195,7 +189,6 @@ TEST_CASE("touch input", "[input]")
     SECTION("touch mouse action")
     {
         // this test verifies that a touch down on an inactive client will activate it
-        using namespace Wrapland::Client;
         // create two windows
         auto c1 = showWindow();
         QVERIFY(c1);
@@ -206,7 +199,7 @@ TEST_CASE("touch input", "[input]")
         QVERIFY(c2->control->active);
 
         // also create a sequence started spy as the touch event should be passed through
-        QSignalSpy sequenceStartedSpy(touch.get(), &Touch::sequenceStarted);
+        QSignalSpy sequenceStartedSpy(touch.get(), &Wrapland::Client::Touch::sequenceStarted);
         QVERIFY(sequenceStartedSpy.isValid());
 
         quint32 timestamp = 1;

--- a/tests/integration/virtual_keyboard.cpp
+++ b/tests/integration/virtual_keyboard.cpp
@@ -17,7 +17,7 @@
 #include <linux/input.h>
 #include <memory>
 
-namespace como::detail::test
+namespace como::detail::test::virtual_keyboard
 {
 
 namespace

--- a/tests/integration/window_selection.cpp
+++ b/tests/integration/window_selection.cpp
@@ -16,8 +16,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <catch2/generators/catch_generators.hpp>
 #include <linux/input.h>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -43,17 +41,23 @@ TEST_CASE("window selection", "[win]")
     SECTION("select on window pointer")
     {
         // this test verifies window selection through pointer works
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
-        std::unique_ptr<Pointer> pointer(get_client().interfaces.seat->createPointer());
-        std::unique_ptr<Keyboard> keyboard(get_client().interfaces.seat->createKeyboard());
-        QSignalSpy pointerEnteredSpy(pointer.get(), &Pointer::entered);
+        auto surface = create_surface();
+        QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
+        QVERIFY(shellSurface);
+
+        std::unique_ptr<Wrapland::Client::Pointer> pointer(
+            get_client().interfaces.seat->createPointer());
+        std::unique_ptr<Wrapland::Client::Keyboard> keyboard(
+            get_client().interfaces.seat->createKeyboard());
+
+        QSignalSpy pointerEnteredSpy(pointer.get(), &Wrapland::Client::Pointer::entered);
         QVERIFY(pointerEnteredSpy.isValid());
-        QSignalSpy pointerLeftSpy(pointer.get(), &Pointer::left);
+        QSignalSpy pointerLeftSpy(pointer.get(), &Wrapland::Client::Pointer::left);
         QVERIFY(pointerLeftSpy.isValid());
-        QSignalSpy keyboardEnteredSpy(keyboard.get(), &Keyboard::entered);
+        QSignalSpy keyboardEnteredSpy(keyboard.get(), &Wrapland::Client::Keyboard::entered);
         QVERIFY(keyboardEnteredSpy.isValid());
-        QSignalSpy keyboardLeftSpy(keyboard.get(), &Keyboard::left);
+        QSignalSpy keyboardLeftSpy(keyboard.get(), &Wrapland::Client::Keyboard::left);
         QVERIFY(keyboardLeftSpy.isValid());
 
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
@@ -118,21 +122,22 @@ TEST_CASE("window selection", "[win]")
     SECTION("select on window keyboard")
     {
         // this test verifies window selection through keyboard key
-
         auto key = GENERATE(KEY_ENTER, KEY_KPENTER, KEY_SPACE);
 
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
-        std::unique_ptr<Pointer> pointer(get_client().interfaces.seat->createPointer());
-        std::unique_ptr<Keyboard> keyboard(get_client().interfaces.seat->createKeyboard());
+        auto surface = create_surface();
+        auto shellSurface = create_xdg_shell_toplevel(surface);
+        std::unique_ptr<Wrapland::Client::Pointer> pointer(
+            get_client().interfaces.seat->createPointer());
+        std::unique_ptr<Wrapland::Client::Keyboard> keyboard(
+            get_client().interfaces.seat->createKeyboard());
 
-        QSignalSpy pointerEnteredSpy(pointer.get(), &Pointer::entered);
+        QSignalSpy pointerEnteredSpy(pointer.get(), &Wrapland::Client::Pointer::entered);
         QVERIFY(pointerEnteredSpy.isValid());
-        QSignalSpy pointerLeftSpy(pointer.get(), &Pointer::left);
+        QSignalSpy pointerLeftSpy(pointer.get(), &Wrapland::Client::Pointer::left);
         QVERIFY(pointerLeftSpy.isValid());
-        QSignalSpy keyboardEnteredSpy(keyboard.get(), &Keyboard::entered);
+        QSignalSpy keyboardEnteredSpy(keyboard.get(), &Wrapland::Client::Keyboard::entered);
         QVERIFY(keyboardEnteredSpy.isValid());
-        QSignalSpy keyboardLeftSpy(keyboard.get(), &Keyboard::left);
+        QSignalSpy keyboardLeftSpy(keyboard.get(), &Wrapland::Client::Keyboard::left);
         QVERIFY(keyboardLeftSpy.isValid());
 
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
@@ -195,13 +200,17 @@ TEST_CASE("window selection", "[win]")
     SECTION("select on window touch")
     {
         // this test verifies window selection through touch
-        std::unique_ptr<Touch> touch(get_client().interfaces.seat->createTouch());
-        QSignalSpy touchStartedSpy(touch.get(), &Touch::sequenceStarted);
+        std::unique_ptr<Wrapland::Client::Touch> touch(get_client().interfaces.seat->createTouch());
+        QSignalSpy touchStartedSpy(touch.get(), &Wrapland::Client::Touch::sequenceStarted);
         QVERIFY(touchStartedSpy.isValid());
-        QSignalSpy touchCanceledSpy(touch.get(), &Touch::sequenceCanceled);
+        QSignalSpy touchCanceledSpy(touch.get(), &Wrapland::Client::Touch::sequenceCanceled);
         QVERIFY(touchCanceledSpy.isValid());
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+
+        auto surface = create_surface();
+        QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
+        QVERIFY(shellSurface);
+
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
         QVERIFY(client);
 
@@ -258,17 +267,23 @@ TEST_CASE("window selection", "[win]")
     SECTION("cancel on window pointer")
     {
         // this test verifies that window selection cancels through right button click
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
-        std::unique_ptr<Pointer> pointer(get_client().interfaces.seat->createPointer());
-        std::unique_ptr<Keyboard> keyboard(get_client().interfaces.seat->createKeyboard());
-        QSignalSpy pointerEnteredSpy(pointer.get(), &Pointer::entered);
+        auto surface = create_surface();
+        QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
+        QVERIFY(shellSurface);
+
+        std::unique_ptr<Wrapland::Client::Pointer> pointer(
+            get_client().interfaces.seat->createPointer());
+        std::unique_ptr<Wrapland::Client::Keyboard> keyboard(
+            get_client().interfaces.seat->createKeyboard());
+
+        QSignalSpy pointerEnteredSpy(pointer.get(), &Wrapland::Client::Pointer::entered);
         QVERIFY(pointerEnteredSpy.isValid());
-        QSignalSpy pointerLeftSpy(pointer.get(), &Pointer::left);
+        QSignalSpy pointerLeftSpy(pointer.get(), &Wrapland::Client::Pointer::left);
         QVERIFY(pointerLeftSpy.isValid());
-        QSignalSpy keyboardEnteredSpy(keyboard.get(), &Keyboard::entered);
+        QSignalSpy keyboardEnteredSpy(keyboard.get(), &Wrapland::Client::Keyboard::entered);
         QVERIFY(keyboardEnteredSpy.isValid());
-        QSignalSpy keyboardLeftSpy(keyboard.get(), &Keyboard::left);
+        QSignalSpy keyboardLeftSpy(keyboard.get(), &Wrapland::Client::Keyboard::left);
         QVERIFY(keyboardLeftSpy.isValid());
 
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
@@ -315,17 +330,22 @@ TEST_CASE("window selection", "[win]")
     SECTION("cancel on window keyboard")
     {
         // this test verifies that cancel window selection through escape key works
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
-        std::unique_ptr<Pointer> pointer(get_client().interfaces.seat->createPointer());
-        std::unique_ptr<Keyboard> keyboard(get_client().interfaces.seat->createKeyboard());
-        QSignalSpy pointerEnteredSpy(pointer.get(), &Pointer::entered);
+        auto surface = create_surface();
+        QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
+        QVERIFY(shellSurface);
+
+        std::unique_ptr<Wrapland::Client::Pointer> pointer(
+            get_client().interfaces.seat->createPointer());
+        std::unique_ptr<Wrapland::Client::Keyboard> keyboard(
+            get_client().interfaces.seat->createKeyboard());
+        QSignalSpy pointerEnteredSpy(pointer.get(), &Wrapland::Client::Pointer::entered);
         QVERIFY(pointerEnteredSpy.isValid());
-        QSignalSpy pointerLeftSpy(pointer.get(), &Pointer::left);
+        QSignalSpy pointerLeftSpy(pointer.get(), &Wrapland::Client::Pointer::left);
         QVERIFY(pointerLeftSpy.isValid());
-        QSignalSpy keyboardEnteredSpy(keyboard.get(), &Keyboard::entered);
+        QSignalSpy keyboardEnteredSpy(keyboard.get(), &Wrapland::Client::Keyboard::entered);
         QVERIFY(keyboardEnteredSpy.isValid());
-        QSignalSpy keyboardLeftSpy(keyboard.get(), &Keyboard::left);
+        QSignalSpy keyboardLeftSpy(keyboard.get(), &Wrapland::Client::Keyboard::left);
         QVERIFY(keyboardLeftSpy.isValid());
 
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
@@ -372,17 +392,22 @@ TEST_CASE("window selection", "[win]")
     SECTION("select point pointer")
     {
         // this test verifies point selection through pointer works
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
-        std::unique_ptr<Pointer> pointer(get_client().interfaces.seat->createPointer());
-        std::unique_ptr<Keyboard> keyboard(get_client().interfaces.seat->createKeyboard());
-        QSignalSpy pointerEnteredSpy(pointer.get(), &Pointer::entered);
+        auto surface = create_surface();
+        QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
+        QVERIFY(shellSurface);
+
+        std::unique_ptr<Wrapland::Client::Pointer> pointer(
+            get_client().interfaces.seat->createPointer());
+        std::unique_ptr<Wrapland::Client::Keyboard> keyboard(
+            get_client().interfaces.seat->createKeyboard());
+        QSignalSpy pointerEnteredSpy(pointer.get(), &Wrapland::Client::Pointer::entered);
         QVERIFY(pointerEnteredSpy.isValid());
-        QSignalSpy pointerLeftSpy(pointer.get(), &Pointer::left);
+        QSignalSpy pointerLeftSpy(pointer.get(), &Wrapland::Client::Pointer::left);
         QVERIFY(pointerLeftSpy.isValid());
-        QSignalSpy keyboardEnteredSpy(keyboard.get(), &Keyboard::entered);
+        QSignalSpy keyboardEnteredSpy(keyboard.get(), &Wrapland::Client::Keyboard::entered);
         QVERIFY(keyboardEnteredSpy.isValid());
-        QSignalSpy keyboardLeftSpy(keyboard.get(), &Keyboard::left);
+        QSignalSpy keyboardLeftSpy(keyboard.get(), &Wrapland::Client::Keyboard::left);
         QVERIFY(keyboardLeftSpy.isValid());
 
         auto client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);

--- a/tests/integration/x11_client.cpp
+++ b/tests/integration/x11_client.cpp
@@ -10,8 +10,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <catch2/generators/catch_generators.hpp>
 #include <xcb/xcb_icccm.h>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -146,8 +144,11 @@ TEST_CASE("x11 window", "[win]")
         QCOMPARE(get_x11_window(setup.base->mod.space->stacking.order.stack.back()), client);
 
         // now let's open a Wayland window
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
+        QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
+        QVERIFY(shellSurface);
+
         auto waylandClient = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
         QVERIFY(waylandClient);
         QVERIFY(waylandClient->control->active);
@@ -299,8 +300,11 @@ TEST_CASE("x11 window", "[win]")
         QVERIFY(client->control->active);
 
         // create Wayland window
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
+        QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
+        QVERIFY(shellSurface);
+
         auto waylandClient = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
         QVERIFY(waylandClient);
         QVERIFY(waylandClient->control->active);
@@ -385,8 +389,11 @@ TEST_CASE("x11 window", "[win]")
         QCOMPARE(rootInfo.activeWindow(), client->xcb_windows.client);
 
         // activate a wayland window
-        std::unique_ptr<Surface> surface(create_surface());
-        std::unique_ptr<XdgShellToplevel> shellSurface(create_xdg_shell_toplevel(surface));
+        auto surface = create_surface();
+        QVERIFY(surface);
+        auto shellSurface = create_xdg_shell_toplevel(surface);
+        QVERIFY(shellSurface);
+
         auto waylandClient = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
         QVERIFY(waylandClient);
         QVERIFY(waylandClient->control->active);

--- a/tests/integration/xdg-shell_rules.cpp
+++ b/tests/integration/xdg-shell_rules.cpp
@@ -11,8 +11,6 @@ SPDX-License-Identifier: GPL-2.0-or-later
 #include <Wrapland/Client/xdg_shell.h>
 #include <linux/input.h>
 
-using namespace Wrapland::Client;
-
 namespace como::detail::test
 {
 
@@ -36,10 +34,11 @@ TEST_CASE("xdg-shell rules", "[win]")
         return {config, group};
     };
 
-    auto createWindow = [&](const QByteArray& appId,
-                            int timeout = 5000) -> std::tuple<wayland_window*,
-                                                              std::unique_ptr<Surface>,
-                                                              std::unique_ptr<XdgShellToplevel>> {
+    auto createWindow =
+        [&](const QByteArray& appId,
+            int timeout = 5000) -> std::tuple<wayland_window*,
+                                              std::unique_ptr<Wrapland::Client::Surface>,
+                                              std::unique_ptr<Wrapland::Client::XdgShellToplevel>> {
         // Create an xdg surface.
         auto surface = create_surface();
         auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
@@ -48,8 +47,9 @@ TEST_CASE("xdg-shell rules", "[win]")
         shellSurface->setAppId(appId);
 
         // Wait for the initial configure event.
-        QSignalSpy configureRequestedSpy(shellSurface.get(), &XdgShellToplevel::configured);
-        surface->commit(Surface::CommitFlag::None);
+        QSignalSpy configureRequestedSpy(shellSurface.get(),
+                                         &Wrapland::Client::XdgShellToplevel::configured);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
         configureRequestedSpy.wait();
 
         // Draw content of the surface.
@@ -89,8 +89,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->active);
@@ -122,8 +122,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->active);
@@ -199,8 +199,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->active);
@@ -276,8 +276,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->active);
@@ -321,8 +321,8 @@ TEST_CASE("xdg-shell rules", "[win]")
     {
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->active);
@@ -412,8 +412,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->active);
@@ -468,16 +468,16 @@ TEST_CASE("xdg-shell rules", "[win]")
         win::space_reconfigure(*setup.base->mod.space);
 
         // Create the test client.
-        std::unique_ptr<Surface> surface = create_surface();
-        std::unique_ptr<XdgShellToplevel> shellSurface
+        std::unique_ptr<Wrapland::Client::Surface> surface = create_surface();
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface
             = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
 
         std::unique_ptr<QSignalSpy> configureRequestedSpy;
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
 
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         // The window size shouldn't be enforced by the rule.
         QVERIFY(configureRequestedSpy->wait());
@@ -519,13 +519,12 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         auto surface = create_surface();
-        std::unique_ptr<XdgShellToplevel> shellSurface
-            = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
+        auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         std::unique_ptr<QSignalSpy> configureRequestedSpy;
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         // The initial configure event should contain size hint set by the rule.
         QVERIFY(configureRequestedSpy->wait());
@@ -533,8 +532,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         auto cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(480, 640));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::resizing));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::resizing));
 
         // Map the client.
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
@@ -549,8 +548,8 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 2);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::resizing));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::resizing));
 
         // One still should be able to resize the client.
         QSignalSpy geometryChangedSpy(client->qobject.get(),
@@ -578,8 +577,8 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 3);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::resizing));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::resizing));
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
 
         auto const cursorPos = cursor()->pos();
@@ -590,9 +589,10 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 4);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::resizing));
-        QVERIFY(cfgdata.updates.testFlag(xdg_shell_toplevel_configure_change::size));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::resizing));
+        QVERIFY(
+            cfgdata.updates.testFlag(Wrapland::Client::xdg_shell_toplevel_configure_change::size));
         QCOMPARE(cfgdata.size, QSize(488, 640));
         QCOMPARE(clientStepUserMovedResizedSpy.count(), 0);
 
@@ -619,9 +619,9 @@ TEST_CASE("xdg-shell rules", "[win]")
         surface = create_surface();
         shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         QVERIFY(configureRequestedSpy->wait());
         QCOMPARE(configureRequestedSpy->count(), 1);
@@ -663,9 +663,9 @@ TEST_CASE("xdg-shell rules", "[win]")
         auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         std::unique_ptr<QSignalSpy> configureRequestedSpy;
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         // The initial configure event should contain size hint set by the rule.
         QVERIFY(configureRequestedSpy->wait());
@@ -673,8 +673,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         auto cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(480, 640));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::resizing));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::resizing));
 
         // Map the client.
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
@@ -689,8 +689,8 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 2);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::resizing));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::resizing));
 
         // One should still be able to resize the client.
         QSignalSpy geometryChangedSpy(client->qobject.get(),
@@ -718,8 +718,8 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 3);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::resizing));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::resizing));
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
 
         auto const cursorPos = cursor()->pos();
@@ -730,9 +730,10 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 4);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::resizing));
-        QVERIFY(cfgdata.updates.testFlag(xdg_shell_toplevel_configure_change::size));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::resizing));
+        QVERIFY(
+            cfgdata.updates.testFlag(Wrapland::Client::xdg_shell_toplevel_configure_change::size));
         QCOMPARE(cfgdata.size, QSize(488, 640));
         QCOMPARE(clientStepUserMovedResizedSpy.count(), 0);
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
@@ -758,9 +759,9 @@ TEST_CASE("xdg-shell rules", "[win]")
         surface = create_surface();
         shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         QVERIFY(configureRequestedSpy->wait());
         QCOMPARE(configureRequestedSpy->count(), 1);
@@ -802,9 +803,9 @@ TEST_CASE("xdg-shell rules", "[win]")
         auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         std::unique_ptr<QSignalSpy> configureRequestedSpy;
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         // The initial configure event should contain size hint set by the rule.
         QVERIFY(configureRequestedSpy->wait());
@@ -846,9 +847,9 @@ TEST_CASE("xdg-shell rules", "[win]")
         surface = create_surface();
         shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         QVERIFY(configureRequestedSpy->wait());
         QCOMPARE(configureRequestedSpy->count(), 1);
@@ -879,9 +880,9 @@ TEST_CASE("xdg-shell rules", "[win]")
         auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         std::unique_ptr<QSignalSpy> configureRequestedSpy;
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         // The expected surface dimensions should be set by the rule.
         QVERIFY(configureRequestedSpy->wait());
@@ -960,9 +961,9 @@ TEST_CASE("xdg-shell rules", "[win]")
         auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         std::unique_ptr<QSignalSpy> configureRequestedSpy;
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         // The initial configure event should contain size hint set by the rule.
         QVERIFY(configureRequestedSpy->wait());
@@ -1006,9 +1007,9 @@ TEST_CASE("xdg-shell rules", "[win]")
         surface = create_surface();
         shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         QVERIFY(configureRequestedSpy->wait());
         QCOMPARE(configureRequestedSpy->count(), 1);
@@ -1052,9 +1053,9 @@ TEST_CASE("xdg-shell rules", "[win]")
         auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         std::unique_ptr<QSignalSpy> configureRequestedSpy;
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         // Wait for the initial configure event.
         QVERIFY(configureRequestedSpy->wait());
@@ -1062,8 +1063,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         auto cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(0, 0));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Map the client.
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
@@ -1081,8 +1082,8 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 2);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Destroy the client.
         shellSurface.reset();
@@ -1110,9 +1111,9 @@ TEST_CASE("xdg-shell rules", "[win]")
         auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         std::unique_ptr<QSignalSpy> configureRequestedSpy;
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         // Wait for the initial configure event.
         QVERIFY(configureRequestedSpy->wait());
@@ -1120,8 +1121,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         auto cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(1280, 1024));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Map the client.
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
@@ -1138,8 +1139,8 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 2);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // One should still be able to change the maximized state of the client.
         win::active_window_maximize(*setup.base->mod.space);
@@ -1150,8 +1151,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // The size is empty since we did not have a restore size before.
         QVERIFY(cfgdata.size.isEmpty());
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         QSignalSpy geometryChangedSpy(client->qobject.get(),
                                       &win::window_qobject::frame_geometry_changed);
@@ -1171,17 +1172,17 @@ TEST_CASE("xdg-shell rules", "[win]")
         surface = create_surface();
         shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         QVERIFY(configureRequestedSpy->wait());
         QCOMPARE(configureRequestedSpy->count(), 1);
 
         cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(1280, 1024));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
         client = render_and_wait_for_shown(surface, QSize(1280, 1024), Qt::blue);
@@ -1196,8 +1197,8 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 2);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Destroy the client.
         shellSurface.reset();
@@ -1225,9 +1226,9 @@ TEST_CASE("xdg-shell rules", "[win]")
         auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         std::unique_ptr<QSignalSpy> configureRequestedSpy;
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         // Wait for the initial configure event.
         QVERIFY(configureRequestedSpy->wait());
@@ -1235,8 +1236,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         auto cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(1280, 1024));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Map the client.
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
@@ -1253,8 +1254,8 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 2);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // One should still be able to change the maximized state of the client.
         win::active_window_maximize(*setup.base->mod.space);
@@ -1265,8 +1266,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // The size is empty since we did not have a restore size before.
         QVERIFY(cfgdata.size.isEmpty());
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         QSignalSpy geometryChangedSpy(client->qobject.get(),
                                       &win::window_qobject::frame_geometry_changed);
@@ -1285,17 +1286,17 @@ TEST_CASE("xdg-shell rules", "[win]")
         surface = create_surface();
         shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         QVERIFY(configureRequestedSpy->wait());
         QCOMPARE(configureRequestedSpy->count(), 1);
 
         cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(0, 0));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
         client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
@@ -1310,8 +1311,8 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 2);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Destroy the client.
         shellSurface.reset();
@@ -1339,9 +1340,9 @@ TEST_CASE("xdg-shell rules", "[win]")
         auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         std::unique_ptr<QSignalSpy> configureRequestedSpy;
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         // Wait for the initial configure event.
         QVERIFY(configureRequestedSpy->wait());
@@ -1349,8 +1350,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         auto cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(1280, 1024));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Map the client.
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
@@ -1367,8 +1368,8 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 2);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Any attempt to change the maximized state should not succeed.
         const QRect oldGeometry = client->geo.frame;
@@ -1385,17 +1386,17 @@ TEST_CASE("xdg-shell rules", "[win]")
         surface = create_surface();
         shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         QVERIFY(configureRequestedSpy->wait());
         QCOMPARE(configureRequestedSpy->count(), 1);
 
         cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(1280, 1024));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
         client = render_and_wait_for_shown(surface, QSize(1280, 1024), Qt::blue);
@@ -1410,8 +1411,8 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 2);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Destroy the client.
         shellSurface.reset();
@@ -1426,9 +1427,9 @@ TEST_CASE("xdg-shell rules", "[win]")
         auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         std::unique_ptr<QSignalSpy> configureRequestedSpy;
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         // Wait for the initial configure event.
         QVERIFY(configureRequestedSpy->wait());
@@ -1436,8 +1437,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         auto cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(0, 0));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Map the client.
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
@@ -1454,8 +1455,8 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 2);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Initialize RuleBook with the test rule.
         auto [config, group] = get_config();
@@ -1476,8 +1477,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(1280, 1024));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Draw contents of the maximized client.
         QSignalSpy geometryChangedSpy(client->qobject.get(),
@@ -1500,8 +1501,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(100, 50));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
         render(surface, QSize(100, 50), Qt::blue);
@@ -1544,9 +1545,9 @@ TEST_CASE("xdg-shell rules", "[win]")
         auto shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         std::unique_ptr<QSignalSpy> configureRequestedSpy;
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         // Wait for the initial configure event.
         QVERIFY(configureRequestedSpy->wait());
@@ -1554,8 +1555,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         auto cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(1280, 1024));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Map the client.
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
@@ -1572,8 +1573,8 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 2);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Any attempt to change the maximized state should not succeed.
         const QRect oldGeometry = client->geo.frame;
@@ -1590,17 +1591,17 @@ TEST_CASE("xdg-shell rules", "[win]")
         surface = create_surface();
         shellSurface = create_xdg_shell_toplevel(surface, CreationSetup::CreateOnly);
         configureRequestedSpy.reset(
-            new QSignalSpy(shellSurface.get(), &XdgShellToplevel::configured));
+            new QSignalSpy(shellSurface.get(), &Wrapland::Client::XdgShellToplevel::configured));
         shellSurface->setAppId("org.kde.foo");
-        surface->commit(Surface::CommitFlag::None);
+        surface->commit(Wrapland::Client::Surface::CommitFlag::None);
 
         QVERIFY(configureRequestedSpy->wait());
         QCOMPARE(configureRequestedSpy->count(), 1);
 
         cfgdata = shellSurface->get_configure_data();
         QCOMPARE(cfgdata.size, QSize(0, 0));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         shellSurface->ackConfigure(configureRequestedSpy->back().front().value<quint32>());
         client = render_and_wait_for_shown(surface, QSize(100, 50), Qt::blue);
@@ -1615,8 +1616,8 @@ TEST_CASE("xdg-shell rules", "[win]")
         QCOMPARE(configureRequestedSpy->count(), 2);
 
         cfgdata = shellSurface->get_configure_data();
-        QVERIFY(cfgdata.states.testFlag(xdg_shell_state::activated));
-        QVERIFY(!cfgdata.states.testFlag(xdg_shell_state::maximized));
+        QVERIFY(cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::activated));
+        QVERIFY(!cfgdata.states.testFlag(Wrapland::Client::xdg_shell_state::maximized));
 
         // Destroy the client.
         shellSurface.reset();
@@ -1646,8 +1647,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -1683,8 +1684,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -1736,8 +1737,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QCOMPARE(win::get_subspace(*client), 2);
@@ -1786,8 +1787,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -1827,8 +1828,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QCOMPARE(win::get_subspace(*client), 1);
@@ -1888,8 +1889,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -1942,8 +1943,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->isMinimizable());
@@ -1972,8 +1973,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         QSignalSpy toplevel_created_Spy(setup.base->mod.space->xdg_shell.get(),
                                         &Wrapland::Server::XdgShell::toplevelCreated);
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo", 500);
@@ -2026,8 +2027,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->isMinimizable());
@@ -2075,8 +2076,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(!client->isMinimizable());
@@ -2107,8 +2108,8 @@ TEST_CASE("xdg-shell rules", "[win]")
     {
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->isMinimizable());
@@ -2159,8 +2160,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(!client->isMinimizable());
@@ -2202,8 +2203,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2231,8 +2232,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2272,8 +2273,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2315,8 +2316,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2347,8 +2348,8 @@ TEST_CASE("xdg-shell rules", "[win]")
     {
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(!client->control->skip_taskbar());
@@ -2396,8 +2397,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2441,8 +2442,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2470,8 +2471,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2511,8 +2512,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2554,8 +2555,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2586,8 +2587,8 @@ TEST_CASE("xdg-shell rules", "[win]")
     {
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(!client->control->skip_pager());
@@ -2635,8 +2636,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2680,8 +2681,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2709,8 +2710,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2750,8 +2751,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2793,8 +2794,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2825,8 +2826,8 @@ TEST_CASE("xdg-shell rules", "[win]")
     {
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(!client->control->skip_switcher());
@@ -2874,8 +2875,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2919,8 +2920,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2948,8 +2949,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -2989,8 +2990,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -3030,8 +3031,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -3060,8 +3061,8 @@ TEST_CASE("xdg-shell rules", "[win]")
     {
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(!client->control->keep_above);
@@ -3109,8 +3110,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -3156,8 +3157,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -3185,8 +3186,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -3226,8 +3227,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -3267,8 +3268,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -3297,8 +3298,8 @@ TEST_CASE("xdg-shell rules", "[win]")
     {
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(!client->control->keep_below);
@@ -3346,8 +3347,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -3393,8 +3394,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QCOMPARE(client->control->shortcut, QKeySequence());
@@ -3436,8 +3437,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -3517,8 +3518,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -3586,8 +3587,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -3642,8 +3643,8 @@ TEST_CASE("xdg-shell rules", "[win]")
     {
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->shortcut.isEmpty());
@@ -3717,8 +3718,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
 
@@ -3830,8 +3831,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->active);
@@ -3860,8 +3861,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->active);
@@ -3888,8 +3889,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->active);
@@ -3925,8 +3926,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->active);
@@ -3959,8 +3960,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->active);
@@ -3994,8 +3995,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->active);
@@ -4040,8 +4041,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->active);
@@ -4068,8 +4069,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->active);
@@ -4096,8 +4097,8 @@ TEST_CASE("xdg-shell rules", "[win]")
 
         // Create the test client.
         wayland_window* client;
-        std::unique_ptr<Surface> surface;
-        std::unique_ptr<XdgShellToplevel> shellSurface;
+        std::unique_ptr<Wrapland::Client::Surface> surface;
+        std::unique_ptr<Wrapland::Client::XdgShellToplevel> shellSurface;
         std::tie(client, surface, shellSurface) = createWindow("org.kde.foo");
         QVERIFY(client);
         QVERIFY(client->control->active);


### PR DESCRIPTION
* Run tests also on release build.
* Enable Unity Build for test targets. This reduces the compile time by around 40%.
* Run Clang-Tidy with current config.