### PR TITLE
build: drop unused KF6Declarative

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,6 @@ find_package(KF6 ${KF6_MIN_VERSION} REQUIRED COMPONENTS
 )
 # required frameworks by config modules
 find_package(KF6 ${KF6_MIN_VERSION} REQUIRED COMPONENTS
-    Declarative
     KCMUtils
     NewStuff
     Service

--- a/como-config.cmake.in
+++ b/como-config.cmake.in
@@ -16,7 +16,6 @@ find_dependency(KF6 @KF6_MIN_VERSION@ COMPONENTS
   Config
   ConfigWidgets
   CoreAddons
-  Declarative
   GlobalAccel
   I18n
   IdleTime


### PR DESCRIPTION
Found downstream via `LDFLAGS+=-Wl,--as-needed`:
```
$ poudriere testport .../como
[...]
Warning: you might not need LIB_DEPENDS on libKF6CalendarEvents.so
[...]
```
